### PR TITLE
Modify how the create incident from email functionality works slightly

### DIFF
--- a/src/iris/ui/templates/application.html
+++ b/src/iris/ui/templates/application.html
@@ -119,7 +119,7 @@
   </div>
   <div class="module application-email-incidents user-settings">
     <h4>Emails which create incidents</h4>
-    <p class="light">When you send an email with these addresses in the "from" header, a new incident will be created.</p>
+    <p class="light">When you send an email with one of these addresses in the "to" header, a new incident will be created.</p>
     {{#hasKeys @root.emailIncidents }}
     <table id="application-email-incidents-table">
       <thead>


### PR DESCRIPTION
Instead of checking the "from" header, check the "to" header.

The way this works, is someone emails a special email alias, and then that
email address reroutes the email to iris, **preserving** the **_to_** header, and **not**
rewriting the **_from_** header.

Make this functionality work with that setup.