### PR TITLE
Make mode_id not be part of the composite primary key on default_application_mode

### DIFF
--- a/db/schema_0.sql
+++ b/db/schema_0.sql
@@ -318,7 +318,7 @@ CREATE TABLE `default_application_mode` (
   `application_id` int(11) NOT NULL,
   `priority_id` int(11) NOT NULL,
   `mode_id` int(11) NOT NULL,
-  PRIMARY KEY (`mode_id`,`application_id`,`priority_id`),
+  PRIMARY KEY (`application_id`,`priority_id`),
   KEY `default_application_mode_ibfk_1` (`application_id`),
   KEY `default_application_mode_ibfk_2` (`priority_id`),
   KEY `default_application_mode_ibfk_3` (`mode_id`),


### PR DESCRIPTION
- Now we can change the default mode per a priority on an app using a single
  insert ... on duplicate key update.. style query

- Also prevent allowing duplicate default modes per the same app and priority