### PR TITLE
Add UI support for configuring supported modes per app

### DIFF
--- a/src/iris/ui/__init__.py
+++ b/src/iris/ui/__init__.py
@@ -225,7 +225,8 @@ class Application(object):
         resp.content_type = 'text/html'
         resp.body = jinja2_env.get_template('application.html').render(request=req,
                                                                        applications=get_local(req, 'applications'),
-                                                                       priorities=get_local(req, 'priorities'))
+                                                                       priorities=get_local(req, 'priorities'),
+                                                                       modes=get_local(req, 'modes') + ['drop'])
 
 
 class Login():

--- a/src/iris/ui/static/css/iris.css
+++ b/src/iris/ui/static/css/iris.css
@@ -989,6 +989,13 @@ table.dataTable thead .sorting_asc {
   display: none;
 }
 
+#supported-modes-checkboxes input {
+  width: auto;
+}
+
+#supported-modes-checkboxes {
+  height: 30px;
+}
 
 #api-key-box {
   height: 22px;

--- a/src/iris/ui/templates/application.html
+++ b/src/iris/ui/templates/application.html
@@ -68,7 +68,12 @@
     <span class="light">Owners: {{#if owners}}{{#each owners}}<span class="label label-info">{{this}} {{# if @root.showEditOwners }}{{# ifCanShowDeleteUserButton this }}<i class="glyphicon glyphicon-remove remove-owner" data-owner="{{this}}"></i>{{/ifCanShowDeleteUserButton}}{{/if}}</span>{{/each}}{{else}}<i>none</i>{{/if}}</span>
     {{# if @root.showEditOwners }}<form id="add-owner-form"><input type="text" class="form-control border-bottom input-sm typeahead" data-targettype="user" placeholder="Add username" id="add-owner-box"></input><button type="submit" class="btn btn-primary btn-xs">Add</button></form>{{/if}}<br>
     <span class="light">Variables: {{#if variables}}{{#each variables}}<span class="label label-info">{{this}} <i class="glyphicon glyphicon-remove remove-variable" data-variable="{{this}}"></i></span>{{/each}}{{else}}<i>none</i>{{/if}}</span>
-    <form id="add-variable-form"><input type="text" class="form-control border-bottom input-sm" placeholder="Add variable" id="add-variable-box"></input><button type="submit" class="btn btn-primary btn-xs">Add</button></form>
+    <form id="add-variable-form"><input type="text" class="form-control border-bottom input-sm" placeholder="Add variable" id="add-variable-box"></input><button type="submit" class="btn btn-primary btn-xs">Add</button></form><br>
+    <div class="light" id="supported-modes-checkboxes">Supported modes:
+      {{#each @root.modes}}
+        <label><input type="checkbox" name="supported_modes" value="{{this}}" {{# ifIn this @root.supported_modes}}checked{{/ifIn}} {{# if @root.viewMode }}disabled{{else}}{{# ifNot @root.supportEditingSupportedModes}}disabled{{/ifNot}}{{/if}}> {{this}}</label>
+      {{/each}}
+    </div>
     {{# if @root.supportViewingKey }}
     <div id="api-key-box" class="light">API key: {{# if @root.apiKey }}<code>{{ @root.apiKey }}</code>{{else}}<button id="show-api-key-button" class="btn btn-default blue btn-xs">Show</button>{{/if}}</div>
     {{/if}}


### PR DESCRIPTION
The last thing we needed to manually configure via DB edits for iris applications.

- Add a bunch of checkboxes, one per mode that exists in iris, to the
  application page. They're checked if the app supports them.

- The checkboxes are disabled/read only if the user viewing the page isn't
  an admin or if the page isn't in edit mode.

- Log when someone changes the supported modes for an app

- Make it so upon app creation, each newly created app supports all of the
  supported normal modes.