### PR TITLE
Logging/rpc tweaks

### DIFF
--- a/src/iris/sender/quota.py
+++ b/src/iris/sender/quota.py
@@ -168,11 +168,11 @@ class ApplicationQuota(object):
 
     def notify_incident(self, application, limit, duration, plan_name, wait_time):
         if not self.iris_application:
-            logger.warning('Application %s breached hard quota. Cannot notify owners as application is not set')
+            logger.warning('Application %s breached hard quota. Cannot notify owners as application is not set', application)
             return
 
         if not plan_name:
-            logger.error('Application %s breached hard quota. Cannot create iris incident as plan is not set (may have been deleted).')
+            logger.error('Application %s breached hard quota. Cannot create iris incident as plan is not set (may have been deleted).', application)
             return
 
         logger.warning('Application %s breached hard quota. Will create incident using plan %s', application, plan_name)

--- a/src/iris/sender/rpc.py
+++ b/src/iris/sender/rpc.py
@@ -113,8 +113,8 @@ def handle_api_notification_request(socket, address, req):
     if notification.get('template') and notification.get('context'):
         notification['context']['iris'] = notification['context'].get('iris', {})
 
-    logger.info('-> %s OK, to %s:%s (%s)',
-                address, role, target, notification.get('priority', notification.get('mode', '?')))
+    logger.info('-> %s OK, to %s:%s (%s:%s)',
+                address, role, target, notification.get('application', '?'), notification.get('priority', notification.get('mode', '?')))
 
     for _target in expanded_targets:
         temp_notification = notification.copy()
@@ -163,6 +163,10 @@ def handle_api_request(socket, address):
     timeout = Timeout.start_new(rpc_timeout)
     try:
         req = msgpack_unpack_msg_from_socket(socket)
+        if not req:
+            logger.warning('Couldn\'t get msgpack data from %s', address)
+            socket.close()
+            return
         logger.info('%s %s', address, req['endpoint'])
         handler = api_request_handlers.get(req['endpoint'])
         if handler is not None:


### PR DESCRIPTION
- Fill in some missing logger arguments in the quota tooling

- Make it so the RPC messages say which application is responsible for
  the message being sent

- Make the RPC handler check if we recieved msgpack data or not to avoid
  an unnecessary TypeError. This is needed because the e2etests, in an
  attempt to see if the sender is ready to recieve notifications, opens
  a connection and then promptly closes it.