### PR TITLE
ci: fail early on error in install.sh

### DIFF
--- a/.ci/common.sh
+++ b/.ci/common.sh
@@ -1,6 +1,0 @@
-export WORKON_HOME=~/.virtualenvs
-
-[ -e /usr/local/bin/virtualenvwrapper.sh ] && {
-	. /usr/local/bin/virtualenvwrapper.sh;
-	workon iris-api
-}

--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -1,17 +1,18 @@
 #!/bin/bash
+set -e
+
 CI_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${CI_DIR}/common.sh"
 
 bash ${CI_DIR}/run_mysql_docker.sh
 
-sudo pip install virtualenvwrapper
-. /usr/local/bin/virtualenvwrapper.sh
-mkvirtualenv iris-api
-workon iris-api
-
 pushd ${TRAVIS_BUILD_DIR}
+	echo "[*] installing app dependencies..."
 	python setup.py develop
+	echo "[*] pip installing dev_requirements.txt..."
 	pip install -r dev_requirements.txt
 popd
 
 bash ${CI_DIR}/setup_mysql.sh
+
+set +e


### PR DESCRIPTION
also get rid of the unnecessary virtualenv setup since travis build already runs in a virtualenv.