### PR TITLE
OOB Sender validation tweaks

### DIFF
--- a/src/iris/role_lookup/dummy.py
+++ b/src/iris/role_lookup/dummy.py
@@ -1,10 +1,16 @@
 # Copyright (c) LinkedIn Corporation. All rights reserved. Licensed under the BSD-2 Clause license.
 # See LICENSE in the project root for license information.
 
+import logging
+logger = logging.getLogger(__name__)
+
 
 class dummy(object):
     def __init__(self, config):
         pass
 
     def get(self, role, target):
+        if role not in ('team', 'manager') and not role.startswith('oncall'):
+            logger.warning('Deliberately returning 0 results for %s:%s as %s is a nonsensical role', role, target, role)
+            return []
         return ['foo']

--- a/src/iris/role_lookup/dummy.py
+++ b/src/iris/role_lookup/dummy.py
@@ -10,7 +10,7 @@ class dummy(object):
         pass
 
     def get(self, role, target):
-        if role not in ('team', 'manager') and not role.startswith('oncall'):
-            logger.warning('Deliberately returning 0 results for %s:%s as %s is a nonsensical role', role, target, role)
+        if role == '_invalid_role' or target == '_invalid_user':
+            logger.warning('Deliberately returning 0 results for %s:%s', role, target)
             return []
         return ['foo']

--- a/src/iris/sender/quota.py
+++ b/src/iris/sender/quota.py
@@ -220,11 +220,11 @@ class ApplicationQuota(object):
 
     def notify_target(self, application, limit, duration, target_name, target_role):
         if not self.iris_application:
-            logger.warning('Application %s breached soft quota. Cannot notify owners as application is not set')
+            logger.warning('Application %s breached soft quota. Cannot notify owners as application is not set', application)
             return
 
         if not target_name or not target_role:
-            logger.error('Application %s breached soft quota. Cannot notify owner as they aren\'t set (may have been deleted).')
+            logger.error('Application %s breached soft quota. Cannot notify owner as they aren\'t set (may have been deleted).', application)
             return
 
         logger.warning('Application %s breached soft quota. Will notify %s:%s', application, target_role, target_name)

--- a/test/e2etest.py
+++ b/test/e2etest.py
@@ -20,6 +20,9 @@ sender_address = ('localhost', 2321)
 base_url = server + 'v0/'
 ui_url = server
 
+invalid_role = '_invalid_role'
+invalid_user = '_invalid_user'
+
 sample_db_config = {
     'db': {
         'conn': {
@@ -802,11 +805,11 @@ def test_post_plan(sample_user, sample_team, sample_template_name):
 
     # Test bad target
     bad_step['role'] = 'user'
-    bad_step['target'] = 'nonexistentUser'
+    bad_step['target'] = invalid_user
     data['steps'][0][0] = bad_step
     re = requests.post(base_url + 'plans', json=data)
     assert re.status_code == 400
-    assert re.json()['description'] == 'Target nonexistentUser not found for step 1'
+    assert re.json()['description'] == 'Target %s not found for step 1' % invalid_user
 
     # Test bad priority
     bad_step['target'] = sample_team
@@ -1766,7 +1769,7 @@ def test_post_notification(sample_user, sample_application_name):
     assert re.json()['title'] == 'Both body and template are missing'
 
     re = requests.post(base_url + 'notifications', json={
-        'role': 'fakerole123',
+        'role': invalid_role,
         'target': sample_user,
         'subject': 'test',
         'priority': 'low',
@@ -1777,7 +1780,7 @@ def test_post_notification(sample_user, sample_application_name):
 
     re = requests.post(base_url + 'notifications', json={
         'role': 'user',
-        'target': 'fakeuser1324234',
+        'target': invalid_user,
         'subject': 'test',
         'priority': 'low',
         'body': 'foo'

--- a/test/e2etest.py
+++ b/test/e2etest.py
@@ -1721,6 +1721,7 @@ def test_post_notification(sample_user, sample_application_name):
         'role': 'user',
         'target': sample_user,
         'subject': 'test',
+        'body': 'foo'
     })
     assert re.status_code == 400
     assert 'Both priority and mode are missing' in re.text
@@ -1729,7 +1730,8 @@ def test_post_notification(sample_user, sample_application_name):
         'role': 'user',
         'target': sample_user,
         'subject': 'test',
-        'priority': 'fakepriority'
+        'priority': 'fakepriority',
+        'body': 'foo'
     })
     assert re.status_code == 400
     assert 'Invalid priority' in re.text
@@ -1738,7 +1740,8 @@ def test_post_notification(sample_user, sample_application_name):
         'role': 'user',
         'target': sample_user,
         'subject': 'test',
-        'mode': 'fakemode'
+        'mode': 'fakemode',
+        'body': 'foo'
     })
     assert re.status_code == 400
     assert 'Invalid mode' in re.text
@@ -1747,10 +1750,40 @@ def test_post_notification(sample_user, sample_application_name):
         'role': 'user',
         'target': sample_user,
         'subject': 'test',
-        'priority': 'low'
+        'priority': 'low',
+        'body': 'foo'
     }, headers={'authorization': 'hmac %s:boop' % sample_application_name})
     assert re.status_code == 200
     assert re.text == '[]'
+
+    re = requests.post(base_url + 'notifications', json={
+        'role': 'user',
+        'target': sample_user,
+        'subject': 'test',
+        'priority': 'low',
+    }, headers={'authorization': 'hmac %s:boop' % sample_application_name})
+    assert re.status_code == 400
+    assert re.json()['title'] == 'Both body and template are missing'
+
+    re = requests.post(base_url + 'notifications', json={
+        'role': 'fakerole123',
+        'target': sample_user,
+        'subject': 'test',
+        'priority': 'low',
+        'body': 'foo'
+    }, headers={'authorization': 'hmac %s:boop' % sample_application_name})
+    assert re.status_code == 400
+    assert re.json()['description'] == 'INVALID role:target'
+
+    re = requests.post(base_url + 'notifications', json={
+        'role': 'user',
+        'target': 'fakeuser1324234',
+        'subject': 'test',
+        'priority': 'low',
+        'body': 'foo'
+    }, headers={'authorization': 'hmac %s:boop' % sample_application_name})
+    assert re.status_code == 400
+    assert re.json()['description'] == 'INVALID role:target'
 
 
 def test_modify_applicaton_quota(sample_application_name, sample_admin_user, sample_plan_name):


### PR DESCRIPTION
Make OOB sending more stringent and add tests
--

Address https://github.com/linkedin/iris/issues/128

- Add tests which confirm that specifying invalid role/target 400.

- Log the sender reject message in the API logs so we can easier debug
  this without needing to dig into sender logs.

- Add checks in notifications endpoint that require either body
  or a template to be specified, as without both the message will
  not be able to be generate and then sent.

- Also fix quota logging