### PR TITLE
Add optional support for unrolling precomputed ldap lists for targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Setup dev environment
 To install iris with extra features, you can pass in feature flag with pip:
 
 ```bash
-pip install -e '.[ldap,prometheus]'
+pip install -e '.[prometheus]'
 ```
 
 For list of extra features, please see `extras_require` setting in `setup.py`.

--- a/configs/config.dev.yaml
+++ b/configs/config.dev.yaml
@@ -2,7 +2,15 @@ server:
   host: 127.0.0.1
   port: 16649
   disable_auth: True
-role_lookup: dummy
+
+# Enabled modules for resolving complex user roles to individual usernames, processed
+# in the order listed here.
+role_lookups:
+  - user # support for 'role' being username
+  - mailing_list # mailing list config; see bottom of file
+  # - oncall # oncall service integration
+  - dummy # dummy role lookup used for testing purposes. Disable this in production.
+
 metrics: dummy
 
 # Change these to random long values when you run this in production
@@ -95,3 +103,28 @@ healthcheck_path: /tmp/status
 enable_gmail_oneclick: True
 gmail_one_click_url_key: 'foo'
 gmail_one_click_url_endpoint: 'http://localhost:16648/api/v0/gmail-oneclick/relay'
+
+# Optionally, import ldap mailing lists and have the ability to target them in messages
+#ldap_lists:
+#  connection:
+#    url: 'ldaps://your ldap url'
+#    bind_args: ['your bind username', 'your bind password']
+#  search_strings:
+#    get_all_lists_filter: '(&(objectClass=group)(groupCN=*)(groupName=*))'
+#    get_all_sub_lists_filter: '(&(objectClass=group)(partOf=%s)(groupCN=*)(groupName=*))'
+#    list_search_string: 'OU=groups,OU=company,DC=com'
+#    user_search_string: 'OU=users,OU=company,DC=com'
+#    user_membership_filter: '(&(objectClass=user)(userName=*)(partOf=%s))'
+#    user_account_name_field: 'userName'
+#    list_cn_field: 'groupCN'
+#    list_name_field: 'groupName'
+#
+#  # Max depth for recursing nested ldap lists.
+#  max_depth: 3
+#
+#  # If a list result returns at least this many results, don't support unrolling at runtime.
+#  max_unrolled_users: 100
+#
+#  # Every $n users, stop inserting into mysql to avoid crashing it. Comment these out to disable.
+#  user_add_pause_interval: 500
+#  user_add_pause_duration: 1

--- a/db/schema_0.sql
+++ b/db/schema_0.sql
@@ -665,6 +665,32 @@ CREATE TABLE `generic_message_sent_status` (
   CONSTRAINT `generic_message_sent_status_message_id_ibfk` FOREIGN KEY (`message_id`) REFERENCES `message` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
+--
+-- Table structure for table `mailing_list`
+--
+
+DROP TABLE IF EXISTS `mailing_list`;
+CREATE TABLE `mailing_list` (
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `name_idx` (`name`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+
+--
+-- Table structure for table `mailing_list_membership`
+--
+
+DROP TABLE IF EXISTS `mailing_list_membership`;
+CREATE TABLE `mailing_list_membership` (
+  `list_id` bigint(20) NOT NULL,
+  `user_id` bigint(20) NOT NULL,
+  PRIMARY KEY (`list_id`, `user_id`),
+  CONSTRAINT `mailing_list_membership_list_id_ibfk` FOREIGN KEY (`list_id`) REFERENCES `mailing_list` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `mailing_list_membership_user_id_ibfk` FOREIGN KEY (`user_id`) REFERENCES `user` (`target_id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 

--- a/setup.py
+++ b/setup.py
@@ -38,9 +38,9 @@ setuptools.setup(
         'pycrypto==2.6.1',
         'beaker==1.8.0',
         'webassets==0.12.0',
+        'python-ldap==2.4.9'
     ],
     extras_require={
-        'ldap': ['python-ldap==2.4.9'],
         # plugin deps
         'influxdb': ['influxdb'],
         'prometheus': ['prometheus_client'],

--- a/src/iris/bin/sync_targets.py
+++ b/src/iris/bin/sync_targets.py
@@ -19,6 +19,14 @@ from iris import metrics
 from requests.packages.urllib3.exceptions import (
     InsecureRequestWarning, SNIMissingWarning, InsecurePlatformWarning
 )
+
+# Used for the optional ldap mailing list resolving functionality
+import ldap
+from ldap.controls import SimplePagedResultsControl
+from ldap.filter import escape_filter_chars
+import time
+ldap_pagination_size = 1000
+
 requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 requests.packages.urllib3.disable_warnings(SNIMissingWarning)
 requests.packages.urllib3.disable_warnings(InsecurePlatformWarning)
@@ -34,6 +42,10 @@ stats_reset = {
     'teams_added': 0,
     'teams_failed_to_add': 0,
     'user_contacts_updated': 0,
+    'ldap_lists_added': 0,
+    'ldap_memberships_added': 0,
+    'ldap_lists_removed': 0,
+    'ldap_memberships_removed': 0
 }
 
 # logging
@@ -93,7 +105,7 @@ def prune_user(engine, username):
         metrics.incr('sql_errors')
 
 
-def fetch_teams(oncall_base_url):
+def fetch_teams_from_oncall(oncall_base_url):
     try:
         return requests.get('%s/api/v0/teams?fields=name' % oncall_base_url).json()
     except (ValueError, requests.exceptions.RequestException):
@@ -120,7 +132,7 @@ def fix_user_contacts(contacts):
     return contacts
 
 
-def fetch_users(oncall_base_url):
+def fetch_users_from_oncall(oncall_base_url):
 
     try:
         return {user['name']: fix_user_contacts(user['contacts']) for user in requests.get('%s/api/v0/users?fields=name&fields=contacts&fields=active' % oncall_base_url).json() if user['active']}
@@ -129,7 +141,7 @@ def fetch_users(oncall_base_url):
         return {}
 
 
-def sync(config, engine, purge_old_users=True):
+def sync_from_oncall(config, engine, purge_old_users=True):
     # users and teams present in our oncall database
     oncall_base_url = config.get('oncall-api')
 
@@ -137,13 +149,13 @@ def sync(config, engine, purge_old_users=True):
         logger.error('Missing URL to oncall-api, which we use for user/team lookups. Bailing.')
         return
 
-    oncall_users = fetch_users(oncall_base_url)
+    oncall_users = fetch_users_from_oncall(oncall_base_url)
 
     if not oncall_users:
         logger.warning('No users found. Bailing.')
         return
 
-    oncall_team_names = fetch_teams(oncall_base_url)
+    oncall_team_names = fetch_teams_from_oncall(oncall_base_url)
 
     if not oncall_team_names:
         logger.warning('We do not have a list of team names')
@@ -266,6 +278,202 @@ def sync(config, engine, purge_old_users=True):
             prune_user(engine, username)
 
 
+def get_ldap_lists(l, search_strings, parent_list=None):
+    results = set()
+    known_ldap_resp_ctrls = {
+        SimplePagedResultsControl.controlType: SimplePagedResultsControl,
+    }
+    req_ctrl = SimplePagedResultsControl(True, size=ldap_pagination_size, cookie='')
+
+    if parent_list:
+        filterstr = search_strings['get_all_sub_lists_filter'] % escape_filter_chars(parent_list)
+    else:
+        filterstr = search_strings['get_all_lists_filter']
+
+    while True:
+        msgid = l.search_ext(search_strings['list_search_string'],
+                             ldap.SCOPE_SUBTREE,
+                             serverctrls=[req_ctrl],
+                             attrlist=(search_strings['list_cn_field'], search_strings['list_name_field']),
+                             filterstr=filterstr)
+        rtype, rdata, rmsgid, serverctrls = l.result3(msgid, resp_ctrl_classes=known_ldap_resp_ctrls)
+
+        results |= {(data[search_strings['list_cn_field']][0], data[search_strings['list_name_field']][0]) for (dn, data) in rdata}
+
+        pctrls = [c for c in serverctrls
+                  if c.controlType == SimplePagedResultsControl.controlType]
+
+        cookie = pctrls[0].cookie
+        if not cookie:
+            break
+        req_ctrl.cookie = cookie
+
+    return results
+
+
+def get_ldap_list_membership(l, search_strings, list_name):
+    results = set()
+    known_ldap_resp_ctrls = {
+        SimplePagedResultsControl.controlType: SimplePagedResultsControl,
+    }
+    req_ctrl = SimplePagedResultsControl(True, size=ldap_pagination_size, cookie='')
+    while True:
+        msgid = l.search_ext(search_strings['user_search_string'],
+                             ldap.SCOPE_SUBTREE,
+                             serverctrls=[req_ctrl],
+                             attrlist=[search_strings['user_account_name_field']],
+                             filterstr=search_strings['user_membership_filter'] % escape_filter_chars(list_name)
+                             )
+        rtype, rdata, rmsgid, serverctrls = l.result3(msgid, resp_ctrl_classes=known_ldap_resp_ctrls)
+
+        results |= {data[1][search_strings['user_account_name_field']][0] for data in rdata}
+
+        pctrls = [c for c in serverctrls
+                  if c.controlType == SimplePagedResultsControl.controlType]
+
+        cookie = pctrls[0].cookie
+        if not cookie:
+            break
+        req_ctrl.cookie = cookie
+
+    return results
+
+
+def get_ldap_flat_membership(l, search_strings, list_name, max_depth, depth=0, seen_lists=set()):
+    members = get_ldap_list_membership(l, search_strings, list_name)
+
+    new_depth = depth + 1
+    if new_depth <= max_depth:
+        for sub_list, email in get_ldap_lists(l, search_strings, list_name):
+            if sub_list in seen_lists:
+                logger.warning('avoiding nested list loop with already seen list: %s', sub_list)
+                continue
+            else:
+                seen_lists.add(sub_list)
+            sub_list_members = get_ldap_flat_membership(l, search_strings, sub_list, max_depth, new_depth, seen_lists)
+            logger.info('Found %s from %s (depth %s/%s)', len(sub_list_members), email, new_depth, max_depth)
+            members |= sub_list_members
+
+    return members
+
+
+def batch_items_from_list(items, items_per_batch):
+    items = list(items)
+    pos = 0
+    while True:
+        new_pos = pos + items_per_batch
+        items_this_batch = items[pos:new_pos]
+        pos = new_pos
+        if not items_this_batch:
+            break
+        yield items_this_batch
+
+
+def batch_remove_ldap_memberships(session, list_id, members):
+    # Remove these in chunks to avoid a gigantic 'where ID in (..)'
+    # query that has thousands of entries.
+    deletes_per_match = 50
+    for memberships_this_batch in batch_items_from_list(members, deletes_per_match):
+        affected = session.execute('''DELETE FROM `mailing_list_membership`
+                                      WHERE `list_id` = :list_id
+                                      AND `user_id` IN (SELECT `id` FROM `target` WHERE `name` IN :members)''',
+                                   {'list_id': list_id, 'members': tuple(memberships_this_batch)}).rowcount
+        logger.info('Deleted %s members from list id %s', affected, list_id)
+    session.commit()
+
+
+def batch_remove_ldap_lists(session, list_names):
+    # Remove these in chunks to avoid a gigantic 'where ID in (..)'
+    # query that has thousands of entries.
+    deletes_per_match = 50
+    for lists_this_batch in batch_items_from_list(list_names, deletes_per_match):
+        affected = session.execute('''DELETE FROM `mailing_list`
+                                      WHERE `name` IN :list_names''',
+                                   {'list_names': tuple(lists_this_batch)}).rowcount
+
+        logger.info('Deleted %s old mailing lists', affected)
+    session.commit()
+
+
+def sync_ldap_lists(ldap_settings, engine):
+    try:
+        l = ldap.initialize(ldap_settings['connection']['url'])
+    except Exception:
+        logger.exception('Connecting to ldap to get our mailing lists failed.')
+        return
+
+    try:
+        l.simple_bind_s(*ldap_settings['connection']['bind_args'])
+    except Exception:
+        logger.exception('binding to ldap to get our mailing lists failed.')
+        return
+
+    session = sessionmaker(bind=engine)()
+
+    ldap_add_pause_interval = ldap_settings.get('user_add_pause_interval', None)
+    ldap_add_pause_duration = ldap_settings.get('user_add_pause_duration', 1)
+
+    ldap_lists = get_ldap_lists(l, ldap_settings['search_strings'])
+    ldap_lists_count = len(ldap_lists)
+    metrics.set('ldap_lists_found', ldap_lists_count)
+    metrics.set('ldap_memberships_found', 0)
+    logger.info('Found %s ldap lists', ldap_lists_count)
+
+    existing_ldap_lists = {row[0] for row in session.execute('''SELECT `name` FROM `mailing_list`''')}
+    kill_lists = existing_ldap_lists - {item[1] for item in ldap_lists}
+    if kill_lists:
+        metrics.incr('ldap_lists_removed', len(kill_lists))
+        batch_remove_ldap_lists(session, kill_lists)
+
+    user_add_count = 0
+
+    for list_cn, list_name in ldap_lists:
+        members = get_ldap_flat_membership(l, ldap_settings['search_strings'], list_cn, ldap_settings['max_depth'], 0, set())
+
+        if not members:
+            logger.info('Ignoring/pruning empty ldap list %s', list_name)
+            continue
+
+        metrics.incr('ldap_memberships_found', len(members))
+
+        list_id = session.execute('''SELECT `id` FROM `mailing_list` WHERE `name` = :name''', {'name': list_name}).scalar()
+
+        if not list_id:
+            list_id = session.execute('''INSERT INTO `mailing_list` (`name`) VALUES (:name)''', {'name': list_name}).lastrowid
+            session.commit()
+            logger.info('Created list %s with id %s', list_name, list_id)
+            metrics.incr('ldap_lists_added')
+
+        existing_members = {row[0] for row in session.execute('''
+                            SELECT `target`.`name`
+                            FROM `mailing_list_membership`
+                            JOIN `target` ON `target`.`id` = `mailing_list_membership`.`user_id`
+                            WHERE `mailing_list_membership`.`list_id` = :list_id''', {'list_id': list_id})}
+
+        add_members = members - existing_members
+        kill_members = existing_members - members
+
+        if add_members:
+            metrics.incr('ldap_memberships_added', len(add_members))
+
+            for member in add_members:
+                session.execute('''INSERT IGNORE INTO `mailing_list_membership`
+                                   (`list_id`, `user_id`)
+                                   VALUES (:list_id, (SELECT `id` FROM `target` WHERE `name` = :name))''', {'list_id': list_id, 'name': member})
+                logger.info('Added %s to %s', member, list_name)
+                user_add_count += 1
+                if (ldap_add_pause_interval is not None) and (user_add_count % ldap_add_pause_interval) == 0:
+                    logger.info('Pausing for %s seconds every %s users.', ldap_add_pause_duration, ldap_add_pause_interval)
+                    time.sleep(ldap_add_pause_duration)
+
+        if kill_members:
+            metrics.incr('ldap_memberships_removed', len(kill_members))
+            batch_remove_ldap_memberships(session, list_id, kill_members)
+
+    session.commit()
+    session.close()
+
+
 def main():
     config = load_config()
     metrics.init(config, 'iris-sync-targets', stats_reset)
@@ -280,10 +488,17 @@ def main():
     engine = create_engine(config['db']['conn']['str'] % config['db']['conn']['kwargs'],
                            **config['db']['kwargs'])
 
+    # Optionally, maintain an internal list of mailing lists from ldap that can also be
+    # used as targets.
+    ldap_lists = config.get('ldap_lists')
+
     # Initialize these to zero at the start of the app, and don't reset them at every
     # metrics interval
     metrics.set('users_found', 0)
     metrics.set('teams_found', 0)
+
+    metrics.set('ldap_lists_found', 0)
+    metrics.set('ldap_memberships_found', 0)
 
     metrics_task = spawn(metrics.emit_forever)
 
@@ -292,7 +507,15 @@ def main():
             logger.error('metrics task failed, %s', metrics_task.exception)
             metrics_task = spawn(metrics.emit_forever)
 
-        sync(config, engine)
+        sync_from_oncall(config, engine)
+
+        # Do ldap mailing list sync *after* we do the normal sync, to ensure we have the users
+        # which will be in ldap already populated.
+        if ldap_lists:
+            list_run_start = time.time()
+            sync_ldap_lists(ldap_lists, engine)
+            logger.info('Ldap mailing list sync took %.2f seconds', time.time() - list_run_start)
+
         logger.info('Sleeping for %d seconds' % nap_time)
         sleep(nap_time)
 

--- a/src/iris/role_lookup/__init__.py
+++ b/src/iris/role_lookup/__init__.py
@@ -4,5 +4,13 @@
 from iris.custom_import import import_custom_module
 
 
-def get_role_lookup(config):
-    return import_custom_module('iris.role_lookup', config['role_lookup'])(config)
+def get_role_lookups(config):
+
+    modules = config.get('role_lookups', [])
+
+    # Support old behavior when there is just one role_lookup module configured and the
+    # expected implicit user lookup.
+    if not modules:
+        modules = ['user', config['role_lookup']]
+
+    return [import_custom_module('iris.role_lookup', module)(config) for module in modules]

--- a/src/iris/role_lookup/mailing_list.py
+++ b/src/iris/role_lookup/mailing_list.py
@@ -1,0 +1,37 @@
+# Copyright (c) LinkedIn Corporation. All rights reserved. Licensed under the BSD-2 Clause license.
+# See LICENSE in the project root for license information.
+
+from iris import db
+import logging
+logger = logging.getLogger(__name__)
+
+
+class mailing_list(object):
+    def __init__(self, config):
+        self.max_list_names = config.get('ldap_lists', {}).get('max_unrolled_users', 0)
+
+    def get(self, role, target):
+        if role == 'mailing-list':
+            return self.unroll_mailing_list(target)
+        else:
+            return None
+
+    def unroll_mailing_list(self, list_name):
+        connection = db.engine.raw_connection()
+        cursor = connection.cursor()
+        cursor.execute('''SELECT `target`.`name`
+                          FROM `mailing_list_membership`
+                          JOIN `target` ON `mailing_list_membership`.`user_id` = `target`.`id`
+                          JOIN `mailing_list` ON `mailing_list_membership`.`list_id` = `mailing_list`.`id`
+                          WHERE `mailing_list`.`name` = %s''', [list_name])
+        names = [row[0] for row in cursor]
+        cursor.close()
+        connection.close()
+        count = len(names)
+        if self.max_list_names > 0 and count >= self.max_list_names:
+            logger.warn('Not returning any results for list group %s as it contains too many members (%s > %s)',
+                        list_name, count, self.max_list_names)
+            return None
+        else:
+            logger.info('Unrolled %s people from list %s', count, list_name)
+            return names

--- a/src/iris/role_lookup/user.py
+++ b/src/iris/role_lookup/user.py
@@ -1,0 +1,16 @@
+# Copyright (c) LinkedIn Corporation. All rights reserved. Licensed under the BSD-2 Clause license.
+# See LICENSE in the project root for license information.
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+class user(object):
+    def __init__(self, config):
+        pass
+
+    def get(self, role, target):
+        if role == 'user':
+            return [target]
+        else:
+            return None


### PR DESCRIPTION
What this implements:

- Add support for sync'ing groups/memberships from ldap to two new mysql tables
- These users match up with users already in the database so delivery is customized based on user prefs
- Add new special role type "list" which triggers mysql-stored ldap lookup based on target
- This functionality has already been tested with OOB as that is what the use case is requested for
- Configurable runtime limit on number of names to return. Eg if a list contains 3000 members and your limit is set at 100, don't return anything at all.
- Configurable mysql insert pausing between configurable intervals. Eg each 1000 users sleep for 1 second to avoid killing the database.
- Refactor of the role lookup modules, so now you can have multiple of them tried in succession

What remains:

- Functionality in the UI for typeahead against the "list" role, if that is so desired, so it can be used in plan steps.