### PR TITLE
Make the target_roles endpoint work without auth

### DIFF
--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -1661,7 +1661,7 @@ class UserModes(object):
 
 
 class TargetRoles(object):
-    allow_read_only = False
+    allow_read_only = True
 
     def on_get(self, req, resp):
         '''


### PR DESCRIPTION
Currently sender in prod fails to start as it tries to hit this endpoint
without auth and cant. It probably makes more sense to make this endpoint
not need auth than have sender pass it through as this endpoint
doesnt display sensitive info.