### PR TITLE
Don't let arrow keys paginate data table if text fields are focused

### DIFF
--- a/src/iris/ui/static/js/iris.js
+++ b/src/iris/ui/static/js/iris.js
@@ -2393,6 +2393,20 @@ iris = {
     },
     bindArrowKeys: function(dataTable) {
       $(document).keydown(function(e) {
+
+        // Don't paginate a data table if any text fields are focused
+        var focus = false;
+        $('body').find('input, textarea').each(function() {
+          if ($(this).is(':focus')) {
+            focus = true;
+            return false; // bail out of loop
+          }
+        })
+
+        if (focus) {
+          return;
+        }
+
         if (e.keyCode == 37) {
           dataTable.page('previous').draw(false);
         } else if (e.keyCode == 39) {


### PR DESCRIPTION
Fix https://github.com/linkedin/iris/issues/149