### PR TITLE
Allow only specifying email_html and not body or template

### DIFF
--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -1390,9 +1390,10 @@ class Notifications(object):
                 'Both priority and mode are missing, at least one of it is required', '')
 
         # Avoid problems down the line if we have no way of creating the message
-        # body, which happens if both body and template are not specified.
-        if not message.get('body') and not message.get('template'):
-            raise HTTPBadRequest('Both body and template are missing', '')
+        # body, which happens if both body and template are not specified, or if we don't
+        # have email_html
+        if not message.get('body') and not message.get('template') and not message.get('email_html'):
+            raise HTTPBadRequest('Body, template, and email_html are missing, so we cannot construct message.', '')
 
         message['application'] = req.context['app']['name']
         s = socket.create_connection(self.sender_addr)

--- a/test/e2etest.py
+++ b/test/e2etest.py
@@ -1778,9 +1778,20 @@ def test_post_notification(sample_user, sample_application_name):
         'target': sample_user,
         'subject': 'test',
         'priority': 'low',
+        'mode': 'email',
+        'email_html': 'foobar',
+    }, headers={'authorization': 'hmac %s:boop' % sample_application_name})
+    assert re.status_code == 200
+    assert re.text == '[]'
+
+    re = requests.post(base_url + 'notifications', json={
+        'role': 'user',
+        'target': sample_user,
+        'subject': 'test',
+        'priority': 'low',
     }, headers={'authorization': 'hmac %s:boop' % sample_application_name})
     assert re.status_code == 400
-    assert re.json()['title'] == 'Both body and template are missing'
+    assert re.json()['title'] == 'Body, template, and email_html are missing, so we cannot construct message.'
 
     re = requests.post(base_url + 'notifications', json={
         'role': invalid_role,


### PR DESCRIPTION
This will fix a current bug where only specifying email_html in iris-client
does not work when it should.