### PR TITLE
Remaining fixes to allow for lists and users of the same name

### DIFF
--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -375,11 +375,12 @@ reprioritization_setting_query = '''SELECT
     `target_reprioritization`.`count` as `count`,
     `target_reprioritization`.`duration` as `duration`
 FROM `target_reprioritization`
-LEFT JOIN `target` ON `target`.`id` = `target_reprioritization`.`target_id`
-LEFT JOIN `mode` `mode_src` ON `mode_src`.`id` = `target_reprioritization`.`src_mode_id`
-LEFT JOIN `mode` `mode_dst` ON `mode_dst`.`id` = `target_reprioritization`.`dst_mode_id`
+JOIN `target` ON `target`.`id` = `target_reprioritization`.`target_id`
+JOIN `target_type` on `target`.`type_id` = `target_type`.`id`
+JOIN `mode` `mode_src` ON `mode_src`.`id` = `target_reprioritization`.`src_mode_id`
+JOIN `mode` `mode_dst` ON `mode_dst`.`id` = `target_reprioritization`.`dst_mode_id`
 WHERE `target`.`name` = %s
-AND `target`.`type_id` = (SELECT `id` FROM `target_type` WHERE `name` = 'user')
+AND `target_type`.`name` = 'user'
 '''
 
 update_reprioritization_settings_query = '''INSERT INTO target_reprioritization (
@@ -417,9 +418,10 @@ get_target_application_modes_query = '''SELECT
 JOIN `target_application_mode` on `target_application_mode`.`priority_id` = `priority`.`id`
 JOIN `mode` on `mode`.`id` = `target_application_mode`.`mode_id`
 JOIN `target` on `target`.`id` =  `target_application_mode`.`target_id`
+JOIN `target_type` on `target`.`type_id` = `target_type`.`id`
 JOIN `application` on `application`.`id` = `target_application_mode`.`application_id`
 WHERE `target`.`name` = :username
-AND `target`.`type_id` = (SELECT `id` FROM `target_type` WHERE `name` = 'user')
+AND `target_type`.`name` = 'user'
 AND `application`.`name` = :app'''
 
 get_all_users_app_modes_query = '''SELECT

--- a/src/iris/utils.py
+++ b/src/iris/utils.py
@@ -59,8 +59,9 @@ def parse_response(response, mode, source):
             return None, 'claim'
         msg_id = session.execute('''SELECT `message`.`id` from `message`
                                     JOIN `target` on `target`.`id` = `message`.`target_id`
+                                    JOIN `target_type` on `target`.`type_id` = `target_type`.`id`
                                     WHERE `target`.`name` = :target_name
-                                    AND `target`.`type_id` = (SELECT `id` FROM `target_type` WHERE `name` = 'user')
+                                    AND `target_type`.`name` = 'user'
                                     ORDER BY `message`.`id` DESC
                                     LIMIT 1''', {'target_name': target_name}).scalar()
         session.close()
@@ -74,8 +75,9 @@ def parse_response(response, mode, source):
         msg_ids = [row[0] for row in session.execute('''SELECT `message`.`id` from `message`
                                                         JOIN `target` on `target`.`id` = `message`.`target_id`
                                                         JOIN `incident` on `incident`.`id` = `message`.`incident_id`
+                                                        JOIN `target_type` on `target`.`type_id` = `target_type`.`id`
                                                         WHERE `target`.`name` = :target_name
-                                                        AND `target`.`type_id` = (SELECT `id` FROM `target_type` WHERE `name` = 'user')
+                                                        AND `target_type`.`name` = 'user'
                                                         AND `incident`.`active` = TRUE''', {'target_name': target_name})]
         session.close()
         return msg_ids, 'claim_all'

--- a/test/e2etest.py
+++ b/test/e2etest.py
@@ -250,11 +250,12 @@ def create_incident_with_message(application, plan, target, mode):
                           )''', {'application': application, 'plan': plan})
         incident_id = cursor.lastrowid
         assert incident_id
+        conn.commit()
         cursor.execute('''INSERT INTO `message` (`created`, `application_id`, `target_id`, `priority_id`, `mode_id`, `active`, `incident_id`)
                           VALUES(
                                   NOW(),
                                   (SELECT `id` FROM `application` WHERE `name` = %(application)s),
-                                  (SELECT `id` FROM `target` WHERE `name` = %(target)s),
+                                  (SELECT `id` FROM `target` WHERE `name` = %(target)s AND `type_id` = (SELECT `id` FROM `target_type` WHERE `name` = 'user')),
                                   (SELECT `id` FROM `priority` WHERE `name` = 'low'),
                                   (SELECT `id` FROM `mode` WHERE `name` = %(mode)s),
                                   TRUE,


### PR DESCRIPTION
Every place where we select against `target` only by name in the hopes
of finding a user, not a mailing-list, ensure we also check type_id
for the user type. Will fix various "subquery returned more than one
row" type errors and other complexities.