### PR TITLE
Add UI to delete plan

### DIFF
--- a/src/iris/ui/static/css/iris.css
+++ b/src/iris/ui/static/css/iris.css
@@ -1505,6 +1505,10 @@ table.dataTable thead .sorting_asc {
   margin: 0 3px;
 }
 
+h3 .btn-primary {
+  margin: 0 3px;
+}
+
 .border-top {
   border-top: 1px solid #dddedf;
 }

--- a/src/iris/ui/static/js/iris.js
+++ b/src/iris/ui/static/js/iris.js
@@ -139,7 +139,9 @@ iris = {
       createPlanBtn: '#publish-plan',
       clonePlanBtn: '#clone-plan',
       showTestPlanModalBtn: '#test-plan-modal-btn',
+      showDeletePlanModalBtn: '#delete-plan-modal-btn',
       testPlanBtn: '#test-plan',
+      deletePlanBtn: '#delete-plan',
       versionSelect: '.version-select',
       activatePlan: '.badge[data-active="0"]',
       viewRelated: '.view-related',
@@ -212,6 +214,7 @@ iris = {
       $(data.createPlanBtn).on('click', this.createPlan.bind(this));
       data.$page.on('click', data.clonePlanBtn, this.clonePlan.bind(this));
       $(data.testPlanBtn).on('click', this.testPlan.bind(this));
+      $(data.deletePlanBtn).on('click', this.deletePlan.bind(this));
       data.$page.on('click', data.showTestPlanModalBtn, this.testPlanModal.bind(this));
       data.$page.on('change', data.planNotificationInputs, this.updateValues);
       data.$page.on('click', data.aggregationBtn, this.toggleAggregation);
@@ -318,6 +321,20 @@ iris = {
         window.location = '/incidents/' + r
       }).fail(function(r) {
         iris.createAlert('Failed creating test incident: ' + r.responseJSON['title'])
+      }).always(function() {
+        $modal.modal('hide');
+      })
+    },
+    deletePlan: function() {
+      var $modal = $('#delete-plan-modal');
+      $.ajax({
+          url: '/v0/plans/' + this.data.name,
+          method: 'DELETE',
+      }).done(function(r) {
+        window.onbeforeunload = null;
+        window.location = '/plans/';
+      }).fail(function(r) {
+        iris.createAlert('Failed deleting plan: ' + r.responseJSON['title'])
       }).always(function() {
         $modal.modal('hide');
       })

--- a/src/iris/ui/templates/plan.html
+++ b/src/iris/ui/templates/plan.html
@@ -25,6 +25,26 @@
   </div>
 </div>
 
+<!-- Modal for deleting this plan -->
+<div class="modal fade" id="delete-plan-modal" tabindex="-1" role="dialog" aria-labelledby="delete-plan-modal-btn">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        <h4 class="modal-title">Test plan</h4>
+      </div>
+      <div class="modal-body">
+        Do you really want to delete this plan? This will only be successful if the plan has not yet been used in incidents or
+        other areas.
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-danger" id="delete-plan">Delete Plan</button>
+      </div>
+    </div>
+  </div>
+</div>
+
 <!-- Modal for publishing this plan -->
 <div class="modal fade" id="publish-plan-modal" tabindex="-1" role="dialog" aria-labelledby="publish-plan">
   <div class="modal-dialog" role="document">
@@ -73,6 +93,7 @@
     <h3>
       Create a plan <i class="badge" data-active="draft"> </i>
       <button type="button" class="btn btn-primary btn-sm pull-right" data-toggle="modal" data-target="#publish-plan-modal">Publish Plan</button>
+      <button type="button" class="btn btn-danger btn-sm pull-right" data-toggle="modal" data-target="#delete-plan-modal">Delete Plan</button>
     </h3>
     <input type="text" id="plan-name" class="form-control" placeholder="Enter a plan name" value="{{name}}">
     <textarea rows="3" id="plan-desc" class="form-control" placeholder="Briefly describe the plan">{{description}}</textarea>


### PR DESCRIPTION
New "Delete Plan" button appears on the clone/edit view, which opens
a confirmation modal that eventually lets you hit the new delete api
call.

Needed to complete: https://github.com/linkedin/iris/issues/169