### PR TITLE
Plan name sanity checks

### DIFF
--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -1016,7 +1016,14 @@ class Plans(object):
         try:
             run_validation('plan', plan_params)
             now = datetime.datetime.utcnow()
-            plan_name = plan_params['name']
+            plan_name = plan_params['name'].strip()
+
+            if not plan_name:
+                raise HTTPBadRequest('Invalid plan', 'Empty plan name')
+
+            if plan_name.isdigit():
+                raise HTTPBadRequest('Invalid plan', 'Plan name cannot be a number')
+
             # FIXME: catch creator not exist error
 
             tracking_key = plan_params.get('tracking_key')

--- a/test/e2etest.py
+++ b/test/e2etest.py
@@ -742,6 +742,14 @@ def test_plan_routing():
 
 
 def test_post_plan(sample_user, sample_team, sample_template_name):
+    re = requests.post(base_url + 'plans', json={'name': ' '})
+    assert re.status_code == 400
+    assert re.json()['description'] == 'Empty plan name'
+
+    re = requests.post(base_url + 'plans', json={'name': '1234'})
+    assert re.status_code == 400
+    assert re.json()['description'] == 'Plan name cannot be a number'
+
     data = {
         "creator": sample_user,
         "name": sample_user + "-test-foo",


### PR DESCRIPTION
- Plan names cannot be an empty string (currently they can)
- Plan names cannot be a number