### PR TITLE
Various OWA improvements/tweaks

### DIFF
--- a/test/test_owa.py
+++ b/test/test_owa.py
@@ -1,0 +1,28 @@
+from iris.bin.owasync import is_pointless_message
+
+
+def test_is_pointless_message():
+    bad_message_headers = [{
+        'name': 'X-Autoreply',
+        'value': 'yes'
+    }]
+
+    bad_message2_headers = [
+        {
+            'name': 'Auto-Submitted',
+            'value': 'auto-replied'
+        },
+        {
+            'name': 'Precedence',
+            'value': 'bulk'
+        }
+    ]
+
+    good_message_headers = [{
+        'name': 'From',
+        'value': 'Foo Bar <foo@bar.com>'
+    }]
+
+    assert is_pointless_message(bad_message_headers)
+    assert is_pointless_message(bad_message2_headers)
+    assert not is_pointless_message(good_message_headers)


### PR DESCRIPTION
- Mark messages as read even if we fail to post to iris-api. This way, when someone sends
us garbage that isn't a real "claim message," we won't try the same message over and over
and ddos ourselves.

- Mark messages as read in bulk. (exchangelib's bulk_update handles batching for us)

- Don't bother forwarding pointless messages to API. Same criteria as with gmail. Just
  mark them as read. Add metric and test for this.

- Rename metric names to end with _count for consistency