### PR TITLE
Fix team/list names being accepted for OOB user target

### DIFF
--- a/src/iris/bin/sender.py
+++ b/src/iris/bin/sender.py
@@ -593,14 +593,16 @@ def set_target_fallback_mode(message):
         cursor.close()
         connection.close()
 
-        old_mode = message['mode']
+        old_mode = message.get('mode', '')
         message['destination'] = destination
         message['mode'] = mode
         message['mode_id'] = mode_id
         update_message_mode(message)
-        auditlog.message_change(
-            message['message_id'], auditlog.MODE_CHANGE, old_mode, message['mode'],
-            'Changing mode due to original mode failure')
+        message_id = message.get('message_id')
+        if message_id:
+            auditlog.message_change(
+                message_id, auditlog.MODE_CHANGE, old_mode, message['mode'],
+                'Changing mode due to original mode failure')
         return True
     # target doesn't have email either - bail
     except ValueError:

--- a/src/iris/sender/cache.py
+++ b/src/iris/sender/cache.py
@@ -390,7 +390,7 @@ class RoleTargets():
     def initialize_active_targets(self):
         connection = self.engine.raw_connection()
         cursor = connection.cursor()
-        cursor.execute('SELECT `name` FROM `target` WHERE `active` = TRUE')
+        cursor.execute('SELECT `name` FROM `target` WHERE `active` = TRUE AND `target`.`type_id` = (SELECT `id` FROM `target_type` WHERE `name` = "user")')
         self.active_targets = {row[0] for row in cursor}
         cursor.close()
         connection.close()


### PR DESCRIPTION
Currently, if you send iris an OOB message with the role
being "user" and the target name being the name of a valid mailing
list or team, it will accept the message, and then cause sender to fail
as it won't be able to assign a contact to the message.

Fix that, so instead the request will fail to begin with instead of
causing sender errors.

Also fix some KeyError's