### PR TITLE
Automatic sender leader election and failover.

### DIFF
--- a/configs/config.dev.yaml
+++ b/configs/config.dev.yaml
@@ -58,9 +58,8 @@ sender:
   debug: True
   host: 127.0.0.1
   port: 2321
-  is_master: True
 
-  # Sender that iris's notifications endpoint sends to
+  # Default sender to reach out to if we can't determine one programmatically
   master_sender:
     host: 127.0.0.1
     port: 2321

--- a/db/schema_0.sql
+++ b/db/schema_0.sql
@@ -692,6 +692,23 @@ CREATE TABLE `mailing_list_membership` (
   CONSTRAINT `mailing_list_membership_user_id_ibfk` FOREIGN KEY (`user_id`) REFERENCES `user` (`target_id`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
+--
+-- Table structure for table `sender_election`
+--
+
+CREATE TABLE `sender_master_election` (
+  `anchor` tinyint(3) unsigned NOT NULL,
+  `sender_address` varchar(128) NOT NULL,
+  `last_seen_active` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`anchor`)
+) ENGINE=InnoDB;
+
+CREATE TABLE `sender_instances` (
+  `sender_address` varchar(128) NOT NULL,
+  `last_seen` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`sender_address`)
+) ENGINE=InnoDB;
+
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 

--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -35,6 +35,7 @@ from iris.sender import auditlog
 from iris.sender.quota import (get_application_quotas_query, insert_application_quota_query,
                                required_quota_keys, quota_int_keys)
 
+from iris.sender.coordinator import Coordinator
 from gevent import spawn, sleep
 
 
@@ -1476,9 +1477,9 @@ class Notifications(object):
     allow_read_no_auth = False
     required_attrs = frozenset(['target', 'role', 'subject'])
 
-    def __init__(self, sender_addr):
-        self.sender_addr = sender_addr
-        logger.info('Sender used for notifications: %s:%s', *self.sender_addr)
+    def __init__(self, default_sender_addr):
+        self.default_sender_addr = default_sender_addr
+        self.coordination = Coordinator(None, None)
 
     def on_post(self, req, resp):
         '''
@@ -1581,8 +1582,17 @@ class Notifications(object):
             raise HTTPBadRequest(
                 'body, template, and email_html are missing, so we cannot construct message.')
 
+        sender_addr = self.coordination.get_current_master()
+        if sender_addr:
+            logger.info('Relaying message to current master sender: %s', sender_addr)
+        else:
+            sender_addr = self.default_sender_addr
+            logger.error('Failed getting current sender master. Falling back to %s', sender_addr)
+
         message['application'] = req.context['app']['name']
-        s = socket.create_connection(self.sender_addr)
+
+        s = socket.create_connection(sender_addr)
+
         s.send(msgpack.packb({'endpoint': 'v0/send', 'data': message}))
         sender_resp = utils.msgpack_unpack_msg_from_socket(s)
         s.close()

--- a/src/iris/bin/sender.py
+++ b/src/iris/bin/sender.py
@@ -1118,6 +1118,8 @@ def main():
     global config
     config = load_config()
 
+    start_time = time.time()
+
     logger.info('[-] bootstraping sender...')
     init_sender(config)
     init_plugins(config.get('plugins', {}))
@@ -1194,9 +1196,11 @@ def main():
         for i in bad_workers:
             worker_tasks[i] = spawn(worker)
 
+        now = time.time()
+        metrics.set('sender_uptime', int(now - start_time))
+
         spawn(metrics.emit)
 
-        now = time.time()
         elapsed_time = now - runtime
         nap_time = max(0, interval - elapsed_time)
         logger.info('--> sender loop finished in %s seconds - sleeping %s seconds',

--- a/src/iris/sender/coordinator.py
+++ b/src/iris/sender/coordinator.py
@@ -1,0 +1,106 @@
+import logging
+from iris import db, metrics
+from gevent import sleep
+from itertools import cycle
+
+logger = logging.getLogger(__name__)
+
+UPDATE_FREQUENCY = 3
+SENDER_ALIVE_TIMEOUT = 10
+
+GET_MASTER_QUERY = '''SELECT `sender_address` FROM `sender_master_election` WHERE `anchor` = 1'''
+
+GET_SLAVES_QUERY = '''
+  SELECT `sender_address`
+  FROM `sender_instances`
+  WHERE `last_seen` > NOW() - INTERVAL CAST(:timeout AS UNSIGNED) SECOND
+  AND `sender_address` NOT IN (%s)''' % GET_MASTER_QUERY
+
+UPDATE_MASTER_QUERY = '''
+  INSERT IGNORE INTO `sender_master_election` (`anchor`, `sender_address`, `last_seen_active`) VALUES (
+    1, :me, NOW()
+  ) ON DUPLICATE KEY UPDATE
+    `sender_address` = if(`last_seen_active` < NOW() - INTERVAL CAST(:timeout AS UNSIGNED) SECOND, VALUES(`sender_address`), `sender_address`),
+    `last_seen_active` = if(`sender_address` = VALUES(`sender_address`), VALUES(`last_seen_active`), `last_seen_active`)
+'''
+
+UPDATE_INSTANCES_QUERY = '''
+  INSERT INTO `sender_instances` (`sender_address`, `last_seen`) VALUES(:me, now())
+  ON DUPLICATE KEY UPDATE `last_seen` = NOW()'''
+
+
+class Coordinator(object):
+    def __init__(self, hostname, port):
+        self.me = '%s:%s' % (hostname, port)
+        self.is_master = None
+        self.master = None
+
+    def am_i_master(self):
+        return self.is_master
+
+    def get_current_master(self):
+        session = db.Session()
+        master = session.execute(GET_MASTER_QUERY).scalar()
+        session.close()
+        return self.address_to_tuple(master)
+
+    def address_to_tuple(self, address):
+        try:
+            host, port = address.split(':', 1)
+            return host, int(port)
+        except (IndexError, ValueError):
+            logger.error('Failed getting address tuple from %s', address)
+            return None
+
+    def update_status(self):
+        session = db.Session()
+
+        # Try setting us to the master otherwise do nothing
+        session.execute(UPDATE_MASTER_QUERY, {'me': self.me, 'timeout': SENDER_ALIVE_TIMEOUT})
+        session.commit()
+
+        # Also keep track of us in the list of online senders
+        session.execute(UPDATE_INSTANCES_QUERY, {'me': self.me})
+        session.commit()
+
+        # Keep track of the actual master locally
+        self.master = session.execute(GET_MASTER_QUERY).scalar()
+
+        # Record locally whether we're the master or not
+        self.is_master = self.master == self.me
+
+        # Keep track of the list of slaves (senders online that are not the master) locally
+        slaves = []
+        for row in session.execute(GET_SLAVES_QUERY, {'timeout': SENDER_ALIVE_TIMEOUT}):
+            address = self.address_to_tuple(row[0])
+            if address:
+                slaves.append(address)
+
+        self.slaves = cycle(slaves)
+        self.slave_count = len(slaves)
+
+        session.close()
+
+    def update_forever(self):
+        while True:
+            old_status = self.is_master
+            self.update_status()
+            new_status = self.is_master
+
+            if old_status != new_status:
+                if new_status:
+                    logger.info('I am now the sender master!')
+                else:
+                    logger.info('I am not the sender master. The current master is %s', self.master)
+            else:
+                logger.debug('I %s the master sender.', 'AM' if self.is_master else 'AM NOT')
+
+            logger.debug('I am aware of %s slaves in this cluster', self.slave_count)
+
+            # Only one node in the cluster should ever emit this as 1
+            metrics.set('is_master_sender', int(self.is_master))
+
+            # Every node in the cluster will end up being aware of the slaves
+            metrics.set('slave_instance_count', self.slave_count)
+
+            sleep(UPDATE_FREQUENCY)

--- a/src/iris/sender/coordinator.py
+++ b/src/iris/sender/coordinator.py
@@ -1,12 +1,15 @@
 import logging
 from iris import db, metrics
-from gevent import sleep
+from gevent import sleep, spawn
 from itertools import cycle
 
 logger = logging.getLogger(__name__)
 
 UPDATE_FREQUENCY = 3
 SENDER_ALIVE_TIMEOUT = 10
+
+REMOVE_OLD_INSTANCES_FREQUENCY = 3600
+REMOVE_OLD_INSTANCES_TIMEOUT = 60
 
 GET_MASTER_QUERY = '''SELECT `sender_address` FROM `sender_master_election` WHERE `anchor` = 1'''
 
@@ -28,6 +31,11 @@ UPDATE_INSTANCES_QUERY = '''
   INSERT INTO `sender_instances` (`sender_address`, `last_seen`) VALUES(:me, now())
   ON DUPLICATE KEY UPDATE `last_seen` = NOW()'''
 
+REMOVE_OLD_INSTANCES_QUERY = '''
+  DELETE FROM `sender_instances`
+  WHERE `last_seen` < NOW() - INTERVAL CAST(:old_instances_timeout AS UNSIGNED) SECOND
+'''
+
 
 class Coordinator(object):
     def __init__(self, hostname, port):
@@ -36,14 +44,28 @@ class Coordinator(object):
         self.slaves = cycle([])
         self.slave_count = 0
 
+        self.prune_old_instances_task = None
+
     def am_i_master(self):
         return self.is_master
 
+    # Used for API to get the current master
     def get_current_master(self):
         session = db.Session()
         master = session.execute(GET_MASTER_QUERY).scalar()
         session.close()
         return self.address_to_tuple(master)
+
+    # Used for API to get the current slaves if master can't be reached
+    def get_current_slaves(self):
+        session = db.Session()
+        slaves = []
+        for row in session.execute(GET_SLAVES_QUERY, {'timeout': SENDER_ALIVE_TIMEOUT}):
+            address = self.address_to_tuple(row[0])
+            if address:
+                slaves.append(address)
+        session.close()
+        return slaves
 
     def address_to_tuple(self, address):
         try:
@@ -56,8 +78,11 @@ class Coordinator(object):
     def update_status(self):
         session = db.Session()
 
-        session.execute(UPDATE_MASTER_QUERY, {'me': self.me, 'timeout': SENDER_ALIVE_TIMEOUT})
-        session.commit()
+        try:
+            session.execute(UPDATE_MASTER_QUERY, {'me': self.me, 'timeout': SENDER_ALIVE_TIMEOUT})
+            session.commit()
+        except:
+            logger.exception('Failed updating master status')
 
         self.is_master = session.execute(GET_MASTER_QUERY).scalar() == self.me
 
@@ -74,8 +99,11 @@ class Coordinator(object):
 
         # If we're slave make sure we're kept track of for master
         else:
-            session.execute(UPDATE_INSTANCES_QUERY, {'me': self.me})
-            session.commit()
+            try:
+                session.execute(UPDATE_INSTANCES_QUERY, {'me': self.me})
+                session.commit()
+            except:
+                logger.exception('Failed updating slave status')
 
             self.slave_count = 0
             self.slaves = cycle([])
@@ -101,4 +129,30 @@ class Coordinator(object):
             metrics.set('slave_instance_count', self.slave_count)
             metrics.set('is_master_sender', int(self.is_master))
 
+            # keep track of task to purge old slave instances if i'm master; kill
+            # it otherwise
+            if self.is_master:
+                if not bool(self.prune_old_instances_task):
+                    self.prune_old_instances_task = spawn(self.prune_old_instances)
+            else:
+                if bool(self.prune_old_instances_task):
+                    self.prune_old_instances_task.kill()
+
             sleep(UPDATE_FREQUENCY)
+
+    def prune_old_instances(self):
+        while True:
+            logger.info('Purging any old instances')
+
+            try:
+                session = db.Session()
+                session.execute(REMOVE_OLD_INSTANCES_QUERY, {'old_instances_timeout': REMOVE_OLD_INSTANCES_TIMEOUT})
+                session.commit()
+                session.close()
+            except Exception:
+                logger.exception('Failed purging old instances')
+            finally:
+                if session:
+                    session.close()
+
+            sleep(REMOVE_OLD_INSTANCES_FREQUENCY)

--- a/src/iris/sender/coordinator.py
+++ b/src/iris/sender/coordinator.py
@@ -106,7 +106,7 @@ class Coordinator(object):
 
         cursor.execute(GET_MASTER_QUERY)
         result = cursor.fetchone()
-        self.is_master = result and result[0] == self.me
+        self.is_master = result == (self.me, )
 
         # Keep track of slaves if we're master
         if self.is_master:


### PR DESCRIPTION
- Move slave logic from rpc to new `Coordinator` class
- That `Coordinator` class periodically keeps track of the current master as well as slaves
- Sender now refers to that new class to determine, in realtime, whether or not it's the master and should be doing masterly things.
- Add two new tables:

1) `sender_master_election`: Single row used to keep track of master sender
2) `sender_instances`: One row per sender that exists, so we can determine slaves