### PR TITLE
Clean up "claim all" usability

### DIFF
--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -1346,7 +1346,7 @@ class Incident(object):
 
         with guarded_db_session() as session:
             # claim_incident will close the session
-            is_active = utils.claim_incident(incident_id, owner, session)
+            is_active = utils.claim_incident(incident_id, owner, session)[0]
         resp.status = HTTP_200
         resp.body = ujson.dumps({'incident_id': int(incident_id),
                                  'owner': owner,
@@ -2987,7 +2987,7 @@ class ResponseMixin(object):
             elif isinstance(msg_id, list) and content == 'claim_all':
                 # Claim all functionality.
                 if not msg_id:
-                    return self.iris_sender_app, 'No incidents to claim'
+                    return self.iris_sender_app, 'No active incidents to claim.'
                 is_claim_all = True
                 apps_to_message = defaultdict(list)
                 for mid in msg_id:

--- a/src/iris/plugins/core.py
+++ b/src/iris/plugins/core.py
@@ -63,14 +63,19 @@ class IrisPlugin(object):
         owner = utils.lookup_username_from_contact(mode, source)
         if not owner:
             return 'Failed to identify owner for the incident.'
-        is_active = utils.claim_incident(iid, owner)
+        is_active, info = utils.claim_incident(iid, owner)
         if is_active:
             logger.info(('Failed to claim incident(%s) for message: %s. '
                          'owner: %s, mode: %s, args: %s'),
                         iid, msg_id, owner, mode, args)
             return 'Failed to claim incident for message: %s.' % str(msg_id)
         else:
-            return 'Iris incident(%s) claimed.' % iid
+            msg = 'Iris incident(%s) claimed.' % iid
+
+            if info:
+                msg += ' %s' % info
+
+            return msg
 
     def process_iris_batch_claim(self, msg_id, source, mode, cmd, args=None):
         owner = utils.lookup_username_from_contact(mode, source)

--- a/src/iris/plugins/core.py
+++ b/src/iris/plugins/core.py
@@ -63,19 +63,17 @@ class IrisPlugin(object):
         owner = utils.lookup_username_from_contact(mode, source)
         if not owner:
             return 'Failed to identify owner for the incident.'
-        is_active, info = utils.claim_incident(iid, owner)
+        is_active, previous_owner = utils.claim_incident(iid, owner)
         if is_active:
             logger.info(('Failed to claim incident(%s) for message: %s. '
                          'owner: %s, mode: %s, args: %s'),
                         iid, msg_id, owner, mode, args)
             return 'Failed to claim incident for message: %s.' % str(msg_id)
         else:
-            msg = 'Iris incident(%s) claimed.' % iid
-
-            if info:
-                msg += ' %s' % info
-
-            return msg
+            if previous_owner:
+                return 'Iris incident(%s) claimed, previously claimed by %s.' % (iid, previous_owner)
+            else:
+                return 'Iris incident(%s) claimed.' % iid
 
     def process_iris_batch_claim(self, msg_id, source, mode, cmd, args=None):
         owner = utils.lookup_username_from_contact(mode, source)

--- a/src/iris/utils.py
+++ b/src/iris/utils.py
@@ -159,6 +159,18 @@ def claim_incident(incident_id, owner, session=None):
     '''
     if not session:
         session = db.Session()
+    info = None
+
+    incident_owner = session.execute('''
+      SELECT `target`.`name`
+      FROM `incident`
+      LEFT JOIN `target` ON `target`.`id` = `incident`.`owner_id`
+      WHERE `incident`.`id` = :incident_id
+    ''', {'incident_id': incident_id}).scalar()
+
+    if incident_owner:
+        info = 'FYI this was already claimed by %s.' % incident_owner
+
     active = 0 if owner else 1
     now = datetime.datetime.utcnow()
     session.execute('''UPDATE `incident`
@@ -172,7 +184,7 @@ def claim_incident(incident_id, owner, session=None):
     session.commit()
     session.close()
 
-    return active == 1
+    return active == 1, info
 
 
 def claim_bulk_incidents(incident_ids, owner):

--- a/src/iris/utils.py
+++ b/src/iris/utils.py
@@ -159,17 +159,13 @@ def claim_incident(incident_id, owner, session=None):
     '''
     if not session:
         session = db.Session()
-    info = None
 
-    incident_owner = session.execute('''
+    previous_owner = session.execute('''
       SELECT `target`.`name`
       FROM `incident`
       LEFT JOIN `target` ON `target`.`id` = `incident`.`owner_id`
       WHERE `incident`.`id` = :incident_id
     ''', {'incident_id': incident_id}).scalar()
-
-    if incident_owner:
-        info = 'FYI this was already claimed by %s.' % incident_owner
 
     active = 0 if owner else 1
     now = datetime.datetime.utcnow()
@@ -184,7 +180,7 @@ def claim_incident(incident_id, owner, session=None):
     session.commit()
     session.close()
 
-    return active == 1, info
+    return active == 1, previous_owner
 
 
 def claim_bulk_incidents(incident_ids, owner):

--- a/test/e2etest.py
+++ b/test/e2etest.py
@@ -386,7 +386,7 @@ def test_api_response_phone_call(fake_message_id, fake_incident_id, sample_phone
         'message_id': fake_message_id,
     }, data=data)
     assert re.status_code == 200
-    assert re.content == '{"app_response":"Iris incident(%s) claimed."}' % fake_incident_id
+    assert re.json()['app_response'].startswith('Iris incident(%s) claimed' % fake_incident_id)
 
 
 def test_api_response_batch_phone_call(fake_batch_id, sample_phone, fake_iris_number):
@@ -426,14 +426,14 @@ def test_api_response_sms(fake_message_id, fake_incident_id, sample_phone):
 
     re = requests.post(base_url + 'response/twilio/messages', data=data)
     assert re.status_code == 200
-    assert re.content == '{"app_response":"Iris incident(%s) claimed."}' % fake_incident_id
+    assert re.json()['app_response'].startswith('Iris incident(%s) claimed' % fake_incident_id)
 
     data = base_body.copy()
     data['Body'] = 'Claim   %s claim arg1 arg2' % fake_message_id
 
     re = requests.post(base_url + 'response/twilio/messages', data=data)
     assert re.status_code == 200
-    assert re.content == '{"app_response":"Iris incident(%s) claimed."}' % fake_incident_id
+    assert re.json()['app_response'].startswith('Iris incident(%s) claimed' % fake_incident_id)
 
     data = base_body.copy()
     data['Body'] = fake_message_id

--- a/test/e2etest.py
+++ b/test/e2etest.py
@@ -707,7 +707,7 @@ def test_api_response_already_claimed(sample_user, sample_phone, sample_user2, s
 
     re = requests.post(base_url + 'response/twilio/messages', data=data)
     assert re.status_code == 200
-    assert re.json()['app_response'] == 'Iris incident(%s) claimed. FYI this was already claimed by %s.' % (incident_id, sample_user)
+    assert re.json()['app_response'] == 'Iris incident(%s) claimed, previously claimed by %s.' % (incident_id, sample_user)
 
 
 def test_api_response_email(fake_message_id, sample_email):

--- a/test/e2etest.py
+++ b/test/e2etest.py
@@ -181,6 +181,15 @@ def sample_phone(sample_user):
 
 
 @pytest.fixture(scope='module')
+def sample_phone2(sample_user2):
+    '''Email address of sample_user2'''
+    re = requests.get(base_url + 'users/' + sample_user2, headers=username_header(sample_user2))
+    assert re.status_code == 200
+    data = re.json()
+    return data['contacts']['call']
+
+
+@pytest.fixture(scope='module')
 def superuser_application():
     '''
     application which should have 'allow_other_app_incidents' in DB set to 1,
@@ -293,7 +302,14 @@ def sample_priority():
         return priorities[0]['name']
 
 
-def create_incident_with_message(application, plan, target, mode):
+def create_incident_with_message(application, plan, targets, mode):
+
+    if isinstance(targets, list):
+        multiple_users = True
+    else:
+        targets = [targets]
+        multiple_users = False
+
     with iris_ctl.db_from_config(sample_db_config) as (conn, cursor):
         cursor.execute('''INSERT INTO `incident` (`plan_id`, `created`, `context`, `current_step`, `active`, `application_id`)
                           VALUES (
@@ -307,19 +323,29 @@ def create_incident_with_message(application, plan, target, mode):
         incident_id = cursor.lastrowid
         assert incident_id
         conn.commit()
-        cursor.execute('''INSERT INTO `message` (`created`, `application_id`, `target_id`, `priority_id`, `mode_id`, `active`, `incident_id`)
-                          VALUES(
-                                  NOW(),
-                                  (SELECT `id` FROM `application` WHERE `name` = %(application)s),
-                                  (SELECT `id` FROM `target` WHERE `name` = %(target)s AND `type_id` = (SELECT `id` FROM `target_type` WHERE `name` = 'user')),
-                                  (SELECT `id` FROM `priority` WHERE `name` = 'low'),
-                                  (SELECT `id` FROM `mode` WHERE `name` = %(mode)s),
-                                  TRUE,
-                                  %(incident_id)s
-                          )''', {'application': application, 'target': target, 'mode': mode, 'incident_id': incident_id})
-        assert cursor.lastrowid
-        conn.commit()
-        return incident_id
+
+        users_to_messages = {}
+
+        for target in targets:
+            cursor.execute('''INSERT INTO `message` (`created`, `application_id`, `target_id`, `priority_id`, `mode_id`, `active`, `incident_id`)
+                              VALUES(
+                                      NOW(),
+                                      (SELECT `id` FROM `application` WHERE `name` = %(application)s),
+                                      (SELECT `id` FROM `target` WHERE `name` = %(target)s AND `type_id` = (SELECT `id` FROM `target_type` WHERE `name` = 'user')),
+                                      (SELECT `id` FROM `priority` WHERE `name` = 'low'),
+                                      (SELECT `id` FROM `mode` WHERE `name` = %(mode)s),
+                                      TRUE,
+                                      %(incident_id)s
+                              )''', {'application': application, 'target': target, 'mode': mode, 'incident_id': incident_id})
+            message_id = cursor.lastrowid
+            assert message_id
+            users_to_messages[target] = message_id
+            conn.commit()
+
+        if multiple_users:
+            return incident_id, users_to_messages
+        else:
+            return incident_id
 
 
 def test_api_acls(sample_user, sample_user2):
@@ -477,7 +503,7 @@ def test_api_response_claim_all(sample_user, sample_phone, sample_application_na
     # Shouldn't be any incidents. Verify response in this case.
     re = requests.post(base_url + 'response/twilio/messages', data=sms_claim_all_body)
     assert re.status_code == 200
-    assert re.json()['app_response'] == 'No incidents to claim'
+    assert re.json()['app_response'] == 'No active incidents to claim.'
 
     # Verify SMS with two incidents from the same app
     incident_id_1 = create_incident_with_message(sample_application_name, sample_plan_name, sample_user, 'sms')
@@ -638,6 +664,50 @@ def test_api_response_claim_last(sample_user, sample_phone, sample_application_n
     re = requests.get(base_url + 'incidents/%s' % incident_id)
     assert re.status_code == 200
     assert re.json()['active'] == 0
+
+
+def test_api_response_already_claimed(sample_user, sample_phone, sample_user2, sample_phone2, sample_application_name, sample_plan_name, sample_email):
+    incident_id, message_ids = create_incident_with_message(sample_application_name, sample_plan_name, [sample_user, sample_user2], 'sms')
+    assert incident_id
+    assert message_ids
+
+    base_body = {
+        'AccountSid': 'ACBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',
+        'ToZip': 15108,
+        'FromState': 'CA',
+        'ApiVersion': '2010-04-01',
+    }
+
+    # First user should be able to the claim the incident without issue using claim all
+    data = base_body.copy()
+    data['Body'] = 'claim all'
+    data['From'] = sample_phone
+
+    re = requests.post(base_url + 'response/twilio/messages', data=data)
+    assert re.status_code == 200
+    assert re.json()['app_response'] == 'Iris Incidents claimed (1): %s' % incident_id
+
+    re = requests.get(base_url + 'incidents/%s' % incident_id)
+    assert re.status_code == 200
+    assert re.json()['active'] == 0
+
+    # Second person trying to claim all should get no incidents found
+    data = base_body.copy()
+    data['Body'] = 'claim all'
+    data['From'] = sample_phone2
+
+    re = requests.post(base_url + 'response/twilio/messages', data=data)
+    assert re.status_code == 200
+    assert re.json()['app_response'] == 'No active incidents to claim.'
+
+    # They try again using claim by ID and that incident was already claimed by first person
+    data = base_body.copy()
+    data['Body'] = 'claim %s' % message_ids[sample_user2]
+    data['From'] = sample_phone2
+
+    re = requests.post(base_url + 'response/twilio/messages', data=data)
+    assert re.status_code == 200
+    assert re.json()['app_response'] == 'Iris incident(%s) claimed. FYI this was already claimed by %s.' % (incident_id, sample_user)
 
 
 def test_api_response_email(fake_message_id, sample_email):


### PR DESCRIPTION
- If no incidents are available for claiming, explicitly say "no ACTIVE incidents" are available
- When you hand-specify an ID to claim, have it tell you if it is already claimed and by whom
- Make "No incidents to claim" have the trailing period for grammar/consistency reasons