### PR TITLE
Remove uneeded noise from sender logs

### DIFF
--- a/src/iris/bin/sender.py
+++ b/src/iris/bin/sender.py
@@ -792,7 +792,6 @@ def render(message):
                     'incident_id': message['incident_id']
                 }
                 message['extra_html'] = additional_body
-                logger.info('Added oneclick URL metadata to extra_html key of message %s', message['message_id'])
 
 
 def mark_message_as_sent(message):


### PR DESCRIPTION
This message is spammed very often and it isn't helpful at all.