### PR TITLE
For the 3 daemons, optionally write pid to a file based on env var

### DIFF
--- a/src/iris/bin/owasync.py
+++ b/src/iris/bin/owasync.py
@@ -25,6 +25,16 @@ ch.setFormatter(formatter)
 logger.setLevel(logging.INFO)
 logger.addHandler(ch)
 
+pidfile = os.environ.get('OWA_SYNC_PIDFILE')
+if pidfile:
+    try:
+        pid = os.getpid()
+        with open(pidfile, 'w') as h:
+            h.write('%s\n' % pid)
+            logger.info('Wrote pid %s to %s', pid, pidfile)
+    except IOError:
+        logger.exception('Failed writing pid to %s', pidfile)
+
 default_metrics = {
     'owa_api_failure_count': 0,
     'message_relay_success_count': 0,

--- a/src/iris/bin/sender.py
+++ b/src/iris/bin/sender.py
@@ -188,6 +188,16 @@ ch.setFormatter(formatter)
 logger.setLevel(logging.INFO)
 logger.addHandler(ch)
 
+pidfile = os.environ.get('SENDER_PIDFILE')
+if pidfile:
+    try:
+        pid = os.getpid()
+        with open(pidfile, 'w') as h:
+            h.write('%s\n' % pid)
+            logger.info('Wrote pid %s to %s', pid, pidfile)
+    except IOError:
+        logger.exception('Failed writing pid to %s', pidfile)
+
 
 # rate limiting data structure message key -> minute -> count
 # used to calcuate if a new message exceeds the rate limit

--- a/src/iris/bin/sync_targets.py
+++ b/src/iris/bin/sync_targets.py
@@ -56,6 +56,16 @@ ch.setFormatter(formatter)
 logger.setLevel(logging.INFO)
 logger.addHandler(ch)
 
+pidfile = os.environ.get('SYNC_TARGETS_PIDFILE')
+if pidfile:
+    try:
+        pid = os.getpid()
+        with open(pidfile, 'w') as h:
+            h.write('%s\n' % pid)
+            logger.info('Wrote pid %s to %s', pid, pidfile)
+    except IOError:
+        logger.exception('Failed writing pid to %s', pidfile)
+
 
 def normalize_phone_number(num):
     return format_number(parse(num.decode('utf-8'), 'US'),


### PR DESCRIPTION
So we can use uwsgi's intelligent daemon management which is made
more reliable with access to a file that contains the daemon's pid.

This can also be useful in other cases where one needs to keep track
of these app's pids without relying on bash $! or similar