### PR TITLE
Fix UnicodeEncodeError from SMTP vendor when email has unicode quotes

### DIFF
--- a/src/iris/vendors/iris_smtp.py
+++ b/src/iris/vendors/iris_smtp.py
@@ -68,7 +68,7 @@ class iris_smtp(object):
 
         if plaintext:
             mt = MIMEText(None, 'plain', 'utf-8')
-            mt.set_payload(quopri.encodestring(plaintext))
+            mt.set_payload(quopri.encodestring(plaintext.encode('UTF-8')))
             mt.replace_header('Content-Transfer-Encoding', 'quoted-printable')
             m.attach(mt)
 
@@ -89,7 +89,7 @@ class iris_smtp(object):
             mt = MIMEText(None, 'html', 'utf-8')
             # Google does not like base64 encoded emails for the oneclick button functionalty,
             # so force quoted printable.
-            mt.set_payload(quopri.encodestring(html))
+            mt.set_payload(quopri.encodestring(html.encode('UTF-8')))
             mt.replace_header('Content-Transfer-Encoding', 'quoted-printable')
             m.attach(mt)
 

--- a/test/test_iris_vendor_smtp.py
+++ b/test/test_iris_vendor_smtp.py
@@ -43,3 +43,17 @@ def test_smtp_send_email(mocker):
         ['foo@bar'],
         CheckEmailString())
     mocked_SMPT.return_value.quit.assert_called_once_with()
+
+
+def test_smtp_unicode(mocker):
+    from iris.vendors.iris_smtp import iris_smtp
+    smtp_config = {
+        'smtp_server': 'foo',
+        'from': 'iris@bar',
+    }
+    smtp_vendor = iris_smtp(smtp_config)
+    smtp_vendor.send_email({
+        'destination': 'foo@bar',
+        'subject': 'hello',
+        'body': u'\u201c',
+    })


### PR DESCRIPTION
Also add test which breaks before the iris_smtp change is made