### PR TITLE
pep-3110: Fix deprecated exception syntax

### DIFF
--- a/src/iris/bin/sender.py
+++ b/src/iris/bin/sender.py
@@ -392,14 +392,14 @@ def escalate():
 
                 try:
                     subject = app_tracking_template['email_subject'].render(**context)
-                except Exception, e:
+                except Exception as e:
                     subject = 'plan %s - tracking notification subject failed to render: %s' % (plan['name'], str(e))
                     logger.exception(subject)
                 tracking_message['email_subject'] = subject
 
                 try:
                     body = app_tracking_template['email_text'].render(**context)
-                except Exception, e:
+                except Exception as e:
                     body = 'plan %s - tracking notification body failed to render: %s' % (plan['name'], str(e))
                     logger.exception(body)
                 tracking_message['email_text'] = body
@@ -408,7 +408,7 @@ def escalate():
                 if email_html_tpl:
                     try:
                         html_body = email_html_tpl.render(**context)
-                    except Exception, e:
+                    except Exception as e:
                         html_body = 'plan %s - tracking notification html body failed to render: %s' % (plan['name'], str(e))
                         logger.exception(html_body)
                     tracking_message['email_html'] = html_body

--- a/src/iris/vendors/iris_smtp.py
+++ b/src/iris/vendors/iris_smtp.py
@@ -101,7 +101,7 @@ class iris_smtp(object):
                 smtp.connect(mx[1], 25)
                 conn = smtp
                 break
-            except Exception, e:
+            except Exception as e:
                 logger.exception(e)
 
         if not conn:


### PR DESCRIPTION
PEP-3110 documents the advised syntax changes to exception handling.
Versions of python from 2.6 onwards have supported this syntax (in
preparation for migrations to Python 3.x).

This sereis of changes ensures that all exception handling in Iris is
compliant with this grammar in an effort to make the codebase python 3.x
compatible.