### PR TITLE
(WIP) Utilize a separate history table for (un)claiming incidents

### DIFF
--- a/db/dummy_data.sql
+++ b/db/dummy_data.sql
@@ -182,5 +182,11 @@ INSERT INTO `message` VALUES
     (3, '10018616db1e4cceba3a9f69177c2343', '2017-01-29 23:23:55', '2017-01-25 23:24:55', 8, 1, 'demo1@foo.bar', 35, 40, 35, 'email_subject', 'email_body', 3, 33, 0, 13);
 UNLOCK TABLES;
 
+LOCK TABLES `incident_claim_action` WRITE;
+INSERT INTO `incident_claim_action` VALUES
+    (1, 'claim'),
+    (2, 'unclaim');
+UNLOCK TABLES;
+
 LOCK TABLES `message_changelog` WRITE;
 UNLOCK TABLES;

--- a/db/schema_0.sql
+++ b/db/schema_0.sql
@@ -71,6 +71,44 @@ CREATE TABLE `incident` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
+-- Table structure for table `incident_claim_action`
+--
+
+DROP TABLE IF EXISTS `incident_claim_action`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `incident_claim_action` (
+  `id` tinyint(4) NOT NULL AUTO_INCREMENT,
+  `name` varchar(30) NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE (`name`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `incident_claim`
+--
+
+DROP TABLE IF EXISTS `incident_claim`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `incident_claim` (
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `incident_id` bigint(20) NOT NULL,
+  `target_id` bigint(20) NOT NULL,
+  `time` datetime NOT NULL,
+  `action_id` tinyint(4) NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `ix_incident_claim_time` (`time`),
+  KEY `ix_incident_claim_target_id` (`target_id`),
+  KEY `ix_incident_claim_incident_id` (`incident_id`),
+  KEY `ix_action_claim_action_id` (`action_id`),
+  CONSTRAINT `incident_claim_ibfk_2` FOREIGN KEY (`target_id`) REFERENCES `user` (`target_id`),
+  CONSTRAINT `incident_claim_ibfk_3` FOREIGN KEY (`action_id`) REFERENCES `incident_claim_action` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
 -- Table structure for table `message`
 --
 

--- a/src/iris/ui/templates/incident.html
+++ b/src/iris/ui/templates/incident.html
@@ -80,8 +80,31 @@
         {{/each}}
       </tbody>
     </table>
-    {{/if}}
   </div>
+  {{/if}}
+  {{#if claim_history}}
+  <div class="module">
+    <label><strong>Claim History:</strong></label>
+    <table class="display dataTable" width="100%">
+      <thead>
+        <tr>
+          <td class="light id">Action</td>
+          <td class="light step">User</td>
+          <td class="light target">Time</td>
+        </tr>
+      </thead>
+      <tbody>
+        {{#each claim_history}}
+        <tr>
+          <td><span class="label label-info">{{action}}</span></td>
+          <td>{{user}}</td>
+          <td>{{convertToLocal time}}</td>
+        </tr>
+        {{/each}}
+      </tbody>
+    </table>
+  </div>
+  {{/if}}
 </script>
 {% endraw %}
 {% endblock %}


### PR DESCRIPTION
**WIP because performance is very bad when tested against prod dataset.**

- Avoid `UPDATE`'ing the `active` and `owner_id` columns of the `incident`
  table by the API

- Instead, insert either "claim" or "unclaim" actions into a history
  table

- Show the claim/unclaim actions for a given incident on the incident
  view page