### PR TITLE
Utilize a separate history table for (un)claiming incidents

### DIFF
--- a/db/dummy_data.sql
+++ b/db/dummy_data.sql
@@ -182,5 +182,11 @@ INSERT INTO `message` VALUES
     (3, '10018616db1e4cceba3a9f69177c2343', '2017-01-29 23:23:55', '2017-01-25 23:24:55', 8, 1, 'demo1@foo.bar', 35, 40, 35, 'email_subject', 'email_body', 3, 33, 0, 13);
 UNLOCK TABLES;
 
+LOCK TABLES `incident_claim_action` WRITE;
+INSERT INTO `incident_claim_action` VALUES
+    (1, 'claim'),
+    (2, 'unclaim');
+UNLOCK TABLES;
+
 LOCK TABLES `message_changelog` WRITE;
 UNLOCK TABLES;

--- a/db/schema_0.sql
+++ b/db/schema_0.sql
@@ -71,6 +71,44 @@ CREATE TABLE `incident` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
+-- Table structure for table `incident_claim_action`
+--
+
+DROP TABLE IF EXISTS `incident_claim_action`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `incident_claim_action` (
+  `id` tinyint(4) NOT NULL AUTO_INCREMENT,
+  `name` varchar(30) NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE (`name`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `incident_claim`
+--
+
+DROP TABLE IF EXISTS `incident_claim`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `incident_claim` (
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `incident_id` bigint(20) NOT NULL,
+  `target_id` bigint(20) NOT NULL,
+  `time` datetime NOT NULL,
+  `action_id` tinyint(4) NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `ix_incident_claim_time` (`time`),
+  KEY `ix_incident_claim_target_id` (`target_id`),
+  KEY `ix_incident_claim_incident_id` (`incident_id`),
+  KEY `ix_action_claim_action_id` (`action_id`),
+  CONSTRAINT `incident_claim_ibfk_2` FOREIGN KEY (`target_id`) REFERENCES `user` (`target_id`),
+  CONSTRAINT `incident_claim_ibfk_3` FOREIGN KEY (`action_id`) REFERENCES `incident_claim_action` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
 -- Table structure for table `message`
 --
 

--- a/src/iris/ui/templates/incident.html
+++ b/src/iris/ui/templates/incident.html
@@ -80,8 +80,31 @@
         {{/each}}
       </tbody>
     </table>
-    {{/if}}
   </div>
+  {{/if}}
+  {{#if claim_history}}
+  <div class="module">
+    <label><strong>Claim History:</strong></label>
+    <table class="display dataTable" width="100%">
+      <thead>
+        <tr>
+          <td class="light id">Action</td>
+          <td class="light step">User</td>
+          <td class="light target">Time</td>
+        </tr>
+      </thead>
+      <tbody>
+        {{#each claim_history}}
+        <tr>
+          <td><span class="label label-info">{{action}}</span></td>
+          <td>{{user}}</td>
+          <td>{{convertToLocal time}}</td>
+        </tr>
+        {{/each}}
+      </tbody>
+    </table>
+  </div>
+  {{/if}}
 </script>
 {% endraw %}
 {% endblock %}

--- a/src/iris/utils.py
+++ b/src/iris/utils.py
@@ -76,9 +76,14 @@ def parse_response(response, mode, source):
                                                             JOIN `target` on `target`.`id` = `message`.`target_id`
                                                             JOIN `incident` on `incident`.`id` = `message`.`incident_id`
                                                             JOIN `target_type` on `target`.`type_id` = `target_type`.`id`
+                                                            LEFT JOIN `incident_claim` ON `incident_claim`.`incident_id` = `incident`.`id` AND `incident_claim`.`id` =
+                                                                      (SELECT `id` FROM `incident_claim`
+                                                                       WHERE `incident_claim`.`incident_id` = `incident`.`id` ORDER BY `time` DESC, `id` DESC LIMIT 1)
+                                                            LEFT JOIN `incident_claim_action` ON `incident_claim_action`.`id` = `incident_claim`.`action_id`
                                                             WHERE `target`.`name` = :target_name
                                                             AND `target_type`.`name` = 'user'
-                                                            AND `incident`.`active` = TRUE''', {'target_name': target_name})]
+                                                            AND LEAST(`incident`.`active`, IFNULL(`incident_claim_action`.`name`, "unclaim") != "claim") = TRUE
+                                                           ''', {'target_name': target_name})]
             session.close()
         return msg_ids, 'claim_all'
 
@@ -173,19 +178,30 @@ def claim_incident(incident_id, owner, session=None):
 
     previous_owner = session.execute('''
       SELECT `target`.`name`
-      FROM `incident`
-      LEFT JOIN `target` ON `target`.`id` = `incident`.`owner_id`
-      WHERE `incident`.`id` = :incident_id
+      FROM `incident_claim`
+      LEFT JOIN `target` ON `target`.`id` = `incident_claim`.`target_id`
+      WHERE `incident_claim`.`incident_id` = :incident_id
+      AND `incident_claim`.`action_id` = (SELECT `incident_claim_action`.`id` FROM `incident_claim_action` WHERE `incident_claim_action`.`name` = "claim")
+      ORDER BY `incident_claim`.`time` DESC
+      LIMIT 1
     ''', {'incident_id': incident_id}).scalar()
 
     active = 0 if owner else 1
+    action = 'claim' if owner else 'unclaim'
+
+    # support unclaiming, by assigning the owner of the "unclaim" action to the previous owner
+    owner = owner if owner else previous_owner
+
     now = datetime.datetime.utcnow()
-    session.execute('''UPDATE `incident`
-                       SET `incident`.`updated` = :updated,
-                           `incident`.`active` = :active,
-                           `incident`.`owner_id` = (SELECT `target`.`id` FROM `target` WHERE `target`.`name` = :owner AND `type_id` = (SELECT `id` FROM `target_type` WHERE `name` = 'user'))
-                       WHERE `incident`.`id` = :incident_id''',
-                    {'incident_id': incident_id, 'active': active, 'owner': owner, 'updated': now})
+    session.execute('''
+        INSERT INTO `incident_claim` (`incident_id`, `time`, `action_id`, `target_id`)
+        VALUES (
+            :incident_id,
+            :now,
+            (SELECT `incident_claim_action`.`id` FROM `incident_claim_action` WHERE `incident_claim_action`.`name` = :action),
+            (SELECT `target`.`id` FROM `target` WHERE `target`.`name` = :owner AND `type_id` = (SELECT `id` FROM `target_type` WHERE `name` = 'user'))
+        )
+    ''', {'incident_id': incident_id, 'owner': owner, 'now': now, 'action': action})
 
     session.execute('UPDATE `message` SET `active`=0 WHERE `incident_id`=:incident_id', {'incident_id': incident_id})
     session.commit()
@@ -197,26 +213,44 @@ def claim_incident(incident_id, owner, session=None):
 def claim_bulk_incidents(incident_ids, owner):
     session = db.Session()
     incident_ids = tuple(incident_ids)
-    active = 0 if owner else 1
     now = datetime.datetime.utcnow()
-    session.execute('''UPDATE `incident`
-                       SET `incident`.`updated` = :updated,
-                           `incident`.`active` = :active,
-                           `incident`.`owner_id` = (SELECT `target`.`id` FROM `target` WHERE `target`.`name` = :owner AND `type_id` = (SELECT `id` FROM `target_type` WHERE `name` = 'user'))
-                       WHERE `incident`.`id` IN :incident_ids''',
-                    {'incident_ids': incident_ids, 'active': active, 'owner': owner, 'updated': now})
+
+    action = 'claim' if owner else 'unclaim'
+    for incident_id in incident_ids:
+        session.execute('''
+            INSERT INTO `incident_claim` (`incident_id`, `time`, `action_id`, `target_id`)
+            VALUES (
+                :incident_id,
+                :now,
+                (SELECT `incident_claim_action`.`id` FROM `incident_claim_action` WHERE `incident_claim_action`.`name` = :action),
+                (SELECT `target`.`id` FROM `target` WHERE `target`.`name` = :owner AND `type_id` = (SELECT `id` FROM `target_type` WHERE `name` = 'user'))
+            )
+        ''', {'incident_id': incident_id, 'owner': owner, 'now': now, 'action': action})
+
+    session.commit()
 
     session.execute('UPDATE `message` SET `active`=0 WHERE `incident_id` IN :incident_ids', {'incident_ids': incident_ids})
-    session.commit()
 
     claimed = set()
     not_claimed = set()
 
-    for incident_id, active in session.execute('SELECT `id`, `active` FROM `incident` WHERE `id` IN :incident_ids', {'incident_ids': incident_ids}):
-        if active == 1:
-            not_claimed.add(incident_id)
-        else:
+    check_claimed_sql = '''
+      SELECT `id`, (
+        SELECT `incident_claim_action`.`name` = "claim"
+        FROM `incident_claim`
+        JOIN `incident_claim_action` on `incident_claim_action`.`id` = `incident_claim`.`action_id`
+        WHERE `incident_claim`.`incident_id` = `incident`.`id`
+        ORDER BY `incident_claim`.`time` DESC
+        LIMIT 1
+        )
+      FROM `incident` WHERE `id` IN :incident_ids
+    '''
+
+    for incident_id, is_claimed in session.execute(check_claimed_sql, {'incident_ids': incident_ids}):
+        if is_claimed == 1:
             claimed.add(incident_id)
+        else:
+            not_claimed.add(incident_id)
 
     session.close()
 
@@ -225,17 +259,21 @@ def claim_bulk_incidents(incident_ids, owner):
 
 def claim_incidents_from_batch_id(batch_id, owner):
     session = db.Session()
-    sql = '''UPDATE `incident`
-             JOIN `message` ON `message`.`incident_id` = `incident`.`id`
-             SET `incident`.`owner_id` = (SELECT `target`.`id` FROM `target` WHERE `target`.`name` = :owner AND `target`.`type_id` = (SELECT `id` FROM `target_type` WHERE `name` = 'user')),
-                 `incident`.`updated` = :now, `incident`.`active`=0
-             WHERE `message`.`batch` = :batch_id'''
-    args = {
-        'batch_id': batch_id,
-        'owner': owner,
-        'now': datetime.datetime.utcnow(),
-    }
-    session.execute(sql, args)
+
+    now = datetime.datetime.utcnow()
+    action = 'claim' if owner else 'unclaim'
+
+    for (incident_id, ) in session.execute('''SELECT DISTINCT `incident_id` FROM `message` WHERE `batch` = :batch_id''', {'batch_id': batch_id}):
+        session.execute('''
+            INSERT INTO `incident_claim` (`incident_id`, `time`, `action_id`, `target_id`)
+            VALUES (
+                :incident_id,
+                :now,
+                (SELECT `incident_claim_action`.`id` FROM `incident_claim_action` WHERE `incident_claim_action`.`name` = :action),
+                (SELECT `target`.`id` FROM `target` WHERE `target`.`name` = :owner AND `type_id` = (SELECT `id` FROM `target_type` WHERE `name` = 'user'))
+            )
+        ''', {'incident_id': incident_id, 'owner': owner, 'now': now, 'action': action})
+
     session.execute('''UPDATE `message` `a`
                        JOIN `message` `b` ON `a`.`incident_id` = `b`.`incident_id`
                        SET `a`.`active`=0 WHERE `b`.`batch`=:batch''',


### PR DESCRIPTION
- Avoid UPDATE'ing the `active` and `owner_id` columns of the `incident`
  table by the API, to avoid deadlocks

- Instead, insert either "claim" or "unclaim" actions into a history
  table

- Show the claim/unclaim actions for a given incident on the incident
  view page

- Add/update various tests for the various pieces that these changes touch