### PR TITLE
Avoid DataError when receiving emails with long subjects

### DIFF
--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -2973,7 +2973,7 @@ class ResponseMixin(object):
             data = {
                 'created': datetime.datetime.utcnow(),
                 'application_id': app['id'],
-                'subject': subject,
+                'subject': subject[:240],
                 'target_id': target_id,
                 'body': body,
                 'destination': dest


### PR DESCRIPTION
Cap at 240 as it dies at >255