### PR TITLE
Avoid 5xx with jinja2.exceptions.UndefinedError

### DIFF
--- a/src/iris/ui/__init__.py
+++ b/src/iris/ui/__init__.py
@@ -346,11 +346,20 @@ class JinjaValidate():
         except Exception as e:
             resp.body = ujson.dumps({'error': str(e), 'lineno': e.lineno})
             resp.status = falcon.HTTP_400
-        else:
-            resp.body = ujson.dumps({
-                'template_subject': subject_template.render(sample_context),
-                'template_body': body_template.render(sample_context)
-            })
+            return
+
+        try:
+            rendered_subject = subject_template.render(sample_context),
+            rendered_body = body_template.render(sample_context)
+        except Exception as e:
+            resp.body = ujson.dumps({'error': str(e)})
+            resp.status = falcon.HTTP_400
+            return
+
+        resp.body = ujson.dumps({
+            'template_subject': rendered_subject,
+            'template_body': rendered_body
+        })
 
 
 def init(config, app):


### PR DESCRIPTION
Avoid jinja2.exceptions.UndefinedError exceptions when trying to
call nonexistent functions, like len().

Render the subject/body separately and catch any exceptions that can be raised during that process.