### PR TITLE
Customize iris-sender's process title

### DIFF
--- a/configs/config.dev.yaml
+++ b/configs/config.dev.yaml
@@ -59,6 +59,7 @@ db: &db
     pool_timeout: 60
 sender:
   debug: True
+  process_title: iris-sender
   host: 127.0.0.1
   port: 2321
 

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setuptools.setup(
         'webassets==0.12.0',
         'python-ldap==2.4.9',
         'exchangelib==1.10.0',
+        'setproctitle==1.1.8',
     ],
     extras_require={
         'kazoo': ['kazoo==2.3.1'],

--- a/src/iris/bin/sender.py
+++ b/src/iris/bin/sender.py
@@ -11,6 +11,7 @@ import os
 import socket
 import gevent
 import signal
+import setproctitle
 
 from collections import defaultdict
 from iris.plugins import init_plugins
@@ -1165,6 +1166,12 @@ def init_sender(config):
     gevent.signal(signal.SIGINT, sender_shutdown)
     gevent.signal(signal.SIGTERM, sender_shutdown)
     gevent.signal(signal.SIGQUIT, sender_shutdown)
+
+    process_title = config['sender'].get('process_title')
+
+    if process_title and isinstance(process_title, basestring):
+        setproctitle.setproctitle(process_title)
+        logger.info('Changing process name to %s', process_title)
 
     api_host = config['sender'].get('api_host', 'http://localhost:16649')
     db.init(config)


### PR DESCRIPTION
In pex environments, avoid very long and hard to grep titles for iris-api
when trying to find the sender process