### PR TITLE
Fix smtp vendor test

### DIFF
--- a/test/test_iris_vendor_smtp.py
+++ b/test/test_iris_vendor_smtp.py
@@ -42,7 +42,16 @@ def test_smtp_send_email(mocker):
         ['iris@bar'],
         ['foo@bar'],
         CheckEmailString())
-    mocked_SMPT.return_value.quit.assert_called_once_with()
+
+    mocked_SMPT.reset_mock()
+
+    smtp_vendor.send_email({
+        'destination': 'foo@bar',
+        'subject': 'hello',
+        'body': 'world',
+    })
+
+    mocked_SMPT.assert_not_called()
 
 
 def test_smtp_unicode(mocker):


### PR DESCRIPTION
- Don't check for quit() being called because it's only called on failure
  now

- Do check that we only make a new connection once and not after subsequent
  message sends