### PR TITLE
SMTP Vendor tweaks

### DIFF
--- a/src/iris/bin/sender.py
+++ b/src/iris/bin/sender.py
@@ -982,7 +982,7 @@ def fetch_and_send_message(send_queue):
     retry_count = message.get('retry_count')
     is_retry = retry_count is not None
     if is_retry and retry_count >= MAX_MESSAGE_RETRIES:
-        logger.warning('Maximum retry count for %s breached')
+        logger.warning('Maximum retry count (%s) for %s breached', MAX_MESSAGE_RETRIES, message)
         return
 
     if not is_retry:

--- a/src/iris/vendors/iris_smtp.py
+++ b/src/iris/vendors/iris_smtp.py
@@ -2,7 +2,7 @@
 # See LICENSE in the project root for license information.
 
 from iris.constants import EMAIL_SUPPORT, IM_SUPPORT
-from smtplib import SMTP
+from smtplib import SMTP, SMTPServerDisconnected
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 import quopri
@@ -11,8 +11,10 @@ import markdown
 import dns.resolver
 import dns.exception
 import logging
+import math
+import itertools
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 class iris_smtp(object):
@@ -24,25 +26,117 @@ class iris_smtp(object):
             EMAIL_SUPPORT: self.send_email,
             IM_SUPPORT: self.send_email,
         }
-        self.mx_sorted = []
-        self.smtp_handles = {}  # map mailserver -> connection handle
+
+        self.mx_lookup_expire = None
+        self.mx_lookup_result = None
+
+        self.smtp_connection_counts = None
+        self.smtp_connection_cycle = None
+
+        self.smtp_server = config.get('smtp_server')
+        self.smtp_gateway = config.get('smtp_gateway')
 
         self.smtp_timeout = config.get('timeout', 10)
-        if config.get('smtp_server'):
-            # mock mx record
-            self.mx_sorted.append((0, config['smtp_server']))
-        elif config.get('smtp_gateway'):
-            try:
-                mx_hosts = dns.resolver.query(config['smtp_gateway'], 'MX')
-            except dns.exception.DNSException as e:
-                mx_hosts = []
-                raise Exception('MX error: %s' % e)
-            for mx in mx_hosts:
-                mx_hostname = mx.exchange.to_text().strip('.')
-                self.mx_sorted.append((mx.preference, mx_hostname))
-            self.mx_sorted.sort(key=lambda tup: tup[0])
-        else:
+        self.connections_per_mx = config.get('connections_per_mx', 4)
+
+        if not self.smtp_server and not self.smtp_gateway:
             raise ValueError('Missing SMTP config for sender')
+
+    def get_mx_hosts(self):
+
+        # If we have a stored mx result that isn't expired just give that back
+        if self.mx_lookup_result is not None and (self.mx_lookup_expire == 0 or self.mx_lookup_expire > time.time()):
+            return self.mx_lookup_result
+
+        # If we just have one smtp server hard coded in config, mock it instead of doing a real
+        # mx record lookup
+        if self.smtp_server:
+            self.mx_lookup_result = [(1, self.smtp_server)]
+            self.mx_lookup_expire = 0
+            return self.mx_lookup_result
+
+        # Otherwise do MX record lookups on the given gateway
+        elif self.smtp_gateway:
+            try:
+                mx_hosts = dns.resolver.query(self.smtp_gateway, 'MX')
+            except:
+                logger.exception('Failed looking up MX records for %s', self.smtp_gateway)
+                return []
+            else:
+                self.mx_lookup_expire = mx_hosts.expiration
+                self.mx_lookup_result = sorted((max(1, mx.preference), mx.exchange.to_text().strip('.')) for mx in mx_hosts)
+                return self.mx_lookup_result
+
+    def generate_pool_counts(self):
+        mx_hosts = self.get_mx_hosts()
+        if not mx_hosts:
+            return {}
+
+        first_priority = mx_hosts[0][0]
+
+        counts = {}
+        for priority, host in mx_hosts:
+            host_percentage = first_priority / float(priority)
+            connection_count = int(math.ceil(host_percentage * self.connections_per_mx))
+            counts[host] = connection_count
+
+        return counts
+
+    def maintain_connection_pools(self):
+
+        num_previous_connections = None
+
+        if self.smtp_connection_counts is None:
+            self.smtp_connection_counts = self.generate_pool_counts()
+        else:
+            # MX records haven't expired? Don't regenerate pools and bail
+            if self.mx_lookup_result is not None and (self.mx_lookup_expire == 0 or self.mx_lookup_expire > time.time()):
+                return True
+
+            new_connection_counts = self.generate_pool_counts()
+
+            # If the MX records expired but the values are the same, bail
+            if new_connection_counts == self.smtp_connection_counts:
+                return True
+
+            num_previous_connections = sum(self.smtp_connection_counts.itervalues())
+            self.smtp_connection_counts = new_connection_counts
+
+        connections = []
+
+        for host, count in self.smtp_connection_counts.iteritems():
+            logger.info('Opening %d SMTP connections to %s', count, host)
+            for x in xrange(count):
+                try:
+                    connections.append([host, self.open_smtp_connection(host)])
+                except Exception:
+                    logger.exception('Failed opening smtp connection %d/%d to %s', x + 1, count, host)
+
+        if not connections:
+            return False
+
+        # Atomically set new cycle list and get access to old one
+        old_cycle, self.smtp_connection_cycle = self.smtp_connection_cycle, itertools.cycle(connections)
+
+        # Try to kill all old connections in our old cycle object
+        if num_previous_connections is not None and old_cycle is not None:
+            for x in xrange(num_previous_connections):
+                try:
+                    old_connection = old_cycle.next()
+                except StopIteration:
+                    break
+
+                try:
+                    old_connection[1].quit()
+                except:
+                    pass
+
+        return True
+
+    def open_smtp_connection(self, address):
+        smtp = SMTP(timeout=self.smtp_timeout)
+        smtp.connect(address, 25)
+        return smtp
 
     def send_email(self, message):
         md = markdown.Markdown()
@@ -94,47 +188,64 @@ class iris_smtp(object):
             mt.replace_header('Content-Transfer-Encoding', 'quoted-printable')
             m.attach(mt)
 
-        conn = None
-        used_mx = None
+        # Maintain our connection pools. This will fail if we either have 0 MX records
+        # or fail to actually open connections to any of the MX records themselves
+        if not self.maintain_connection_pools():
+            logger.error('Failed creating any connection pools!')
+            return None
 
-        for mx in self.mx_sorted:
-            old_handle = self.smtp_handles.get(mx)
-
-            # Use previously created connection
-            if old_handle:
-                conn = old_handle
-                used_mx = mx
-                break
-
-            # Otherwise try making a new one and storing it
-            else:
-                logger.info('Opening new MX connection for %s', mx)
-                try:
-                    smtp = SMTP(timeout=self.smtp_timeout)
-                    smtp.connect(mx[1], 25)
-                    conn = smtp
-                    self.smtp_handles[mx] = conn
-                    used_mx = mx
-                    break
-                except Exception as e:
-                    logger.exception('Failed connecting to %s: %s', mx, e)
-
-        if not conn:
-            raise Exception('Failed to get smtp connection.')
+        # Get a connection object from the cycle. Will be a list like [MX Name, MX Handle],
+        # so if we reconnect we can just update the handle in place
+        try:
+            connection = self.smtp_connection_cycle.next()
+        except StopIteration:
+            logger.error('Empty cycle for smtp connections!')
+            return None
 
         try:
-            conn.sendmail([from_address], [message['destination']], m.as_string())
-        except Exception as e:
-            logger.exception('Failed sending email through %s: %s', used_mx, e)
+            connection[1].sendmail([from_address], [message['destination']], m.as_string())
 
-            # When we fail, remove this handle from our map so we try connecting again next round
-            self.smtp_handles.pop(used_mx, None)
+        # If it's a disconnect, probably caused by timeout, try reconnecting and trying again
+        except SMTPServerDisconnected:
+            logger.exception('SMTP server disconnected while trying to send message %s through server %s. Will try to reconnect + send.', message, connection[0])
+
+            # Try cleaning up
+            try:
+                connection[1].quit()
+            except:
+                pass
+
+            # Try restoring this connection object
+            try:
+                connection[1] = self.open_smtp_connection(connection[0])
+            except Exception:
+                logger.exception('Failed reconnecting to SMTP host %s', connection[0])
+                return None
 
             try:
-                conn.quit()
+                connection[1].sendmail([from_address], [message['destination']], m.as_string())
+                logger.info('Message successfully sent through %s after reconnecting', connection[0])
             except Exception:
-                logger.exception('Failed closing SMTP connection')
+                logger.exception('Failed sending message again')
+                return None
 
+        # Anything else just try reconnecting and let this call fail, as it will be retried
+        except Exception:
+            logger.exception('Failed sending message %s through server %s. Will try to reconnect.', message, connection[0])
+
+            # Try cleaning up
+            try:
+                connection[1].quit()
+            except:
+                pass
+
+            # Try restoring this connection object
+            try:
+                connection[1] = self.open_smtp_connection(connection[0])
+            except Exception:
+                logger.exception('Failed reconnecting to SMTP host %s', connection[0])
+
+            # Mark this send as a failure. The message will be retried later.
             return None
 
         return time.time() - start

--- a/test/test_iris_vendor_smtp.py
+++ b/test/test_iris_vendor_smtp.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding:utf-8 -*-
 
+from collections import OrderedDict
+
 
 def test_smtp_vendor_init():
     from iris.vendors.iris_smtp import iris_smtp
@@ -8,8 +10,10 @@ def test_smtp_vendor_init():
         'smtp_server': 'foo'
     }
     smtp_vendor = iris_smtp(smtp_config)
+    assert smtp_vendor.get_mx_hosts() == [(1, 'foo')]
+
     assert smtp_vendor.smtp_timeout == 10
-    assert smtp_vendor.mx_sorted == [(0, 'foo')]
+    assert smtp_vendor.mx_lookup_result == [(1, 'foo')]
 
     smtp_config = {
         'timeout': 20,
@@ -23,6 +27,7 @@ def test_smtp_send_email(mocker):
     from iris.vendors.iris_smtp import iris_smtp
     smtp_config = {
         'smtp_server': 'foo',
+        'connections_per_mx': 1,
         'from': 'iris@bar',
     }
     smtp_vendor = iris_smtp(smtp_config)
@@ -52,6 +57,132 @@ def test_smtp_send_email(mocker):
     })
 
     mocked_SMPT.assert_not_called()
+
+
+def test_smtp_generate_pool_counts(mocker):
+    # A single hard coded server should get 4 connections
+    from iris.vendors.iris_smtp import iris_smtp
+    smtp_config = {
+        'smtp_server': 'fooserver',
+        'connections_per_mx': 4,
+        'from': 'iris@bar',
+    }
+    smtp_vendor = iris_smtp(smtp_config)
+    assert smtp_vendor.generate_pool_counts() == {'fooserver': 4}
+
+    # Two servers with same priority from DNS should get same number of connections,
+    # which is configured to be 4
+    smtp_config = {
+        'smtp_gateway': 'foogateway',
+        'connections_per_mx': 4,
+        'from': 'iris@bar',
+    }
+    smtp_vendor = iris_smtp(smtp_config)
+    smtp_vendor.get_mx_hosts = lambda: [(10, 'fooserver1'), (10, 'fooserver2')]
+    assert smtp_vendor.generate_pool_counts() == {'fooserver1': 4, 'fooserver2': 4}
+
+    # Two servers with differing priority from DNS will get a different number of connections
+    smtp_config = {
+        'smtp_gateway': 'foogateway',
+        'connections_per_mx': 4,
+        'from': 'iris@bar',
+    }
+    smtp_vendor = iris_smtp(smtp_config)
+    smtp_vendor.get_mx_hosts = lambda: [(5, 'fooserver1'), (10, 'fooserver2')]
+    assert smtp_vendor.generate_pool_counts() == {'fooserver1': 4, 'fooserver2': 2}
+
+    # A bunch of servers will follow the same logic
+    smtp_config = {
+        'smtp_gateway': 'foogateway',
+        'connections_per_mx': 4,
+        'from': 'iris@bar',
+    }
+    smtp_vendor = iris_smtp(smtp_config)
+    smtp_vendor.get_mx_hosts = lambda: [(10, 'lowserver1'), (10, 'lowserver2'), (20, 'highserver1')]
+    assert smtp_vendor.generate_pool_counts() == {'lowserver1': 4, 'lowserver2': 4, 'highserver1': 2}
+
+
+def test_maintain_connection_pools(mocker):
+    from iris.vendors.iris_smtp import iris_smtp
+    smtp_config = {
+        'smtp_server': 'fooserver',
+        'from': 'iris@bar',
+    }
+
+    # Simple case where given a single server with 10 connections, we should have called
+    # the open function 10 times and have 10 of this in the cycle
+    smtp_vendor = iris_smtp(smtp_config)
+    smtp_vendor.open_smtp_connection = mocker.Mock()
+    smtp_vendor.generate_pool_counts = lambda: {'fooserver': 10}
+    smtp_vendor.maintain_connection_pools()
+
+    smtp_vendor.open_smtp_connection.assert_called()
+    smtp_vendor.open_smtp_connection.assert_called_with('fooserver')
+    assert smtp_vendor.open_smtp_connection.call_count == 10
+    for x in xrange(10):
+        assert smtp_vendor.smtp_connection_cycle.next()[0] == 'fooserver'
+
+    # More complex case where we should have multiple connections of different servers
+    smtp_vendor = iris_smtp(smtp_config)
+    smtp_vendor.open_smtp_connection = mocker.Mock()
+    smtp_vendor.generate_pool_counts = lambda: OrderedDict((('fooserver', 10), ('twoserver', 2), ('anotherserver', 5)))
+    smtp_vendor.maintain_connection_pools()
+
+    smtp_vendor.open_smtp_connection.assert_called()
+    assert smtp_vendor.open_smtp_connection.call_count == 17
+
+    def test_cycle():
+        for x in xrange(10):
+            assert smtp_vendor.smtp_connection_cycle.next()[0] == 'fooserver'
+
+        for x in xrange(2):
+            assert smtp_vendor.smtp_connection_cycle.next()[0] == 'twoserver'
+
+        for x in xrange(5):
+            assert smtp_vendor.smtp_connection_cycle.next()[0] == 'anotherserver'
+
+    # And around and around we go
+    test_cycle()
+    test_cycle()
+    test_cycle()
+
+    # Change the pool count and see if we recover and close old connections
+    smtp_vendor.open_smtp_connection.reset_mock()
+
+    # Make us reload the correct list of locations
+    smtp_vendor.mx_lookup_result = None
+    smtp_vendor.mx_lookup_expire = 0
+
+    # Change the list of corrections
+    smtp_vendor.generate_pool_counts = lambda: {'newserver': 10}
+
+    # Grab the old cycle before its lost
+    old_cycle = smtp_vendor.smtp_connection_cycle
+
+    # This should create a new cycle and then close all of the old connections
+    smtp_vendor.maintain_connection_pools()
+
+    for x in xrange(10):
+        old_connection = old_cycle.next()
+        assert old_connection[0] == 'fooserver'
+        assert old_connection[1].quit.called
+
+    for x in xrange(2):
+        old_connection = old_cycle.next()
+        assert old_connection[0] == 'twoserver'
+        assert old_connection[1].quit.called
+
+    for x in xrange(5):
+        old_connection = old_cycle.next()
+        assert old_connection[0] == 'anotherserver'
+        assert old_connection[1].quit.called
+
+    # Should have created 10 new instances of newserver
+    smtp_vendor.open_smtp_connection.assert_called()
+    assert smtp_vendor.open_smtp_connection.call_count == 10
+
+    for x in xrange(10):
+        assert smtp_vendor.smtp_connection_cycle.next()[0] == 'newserver'
 
 
 def test_smtp_unicode(mocker):


### PR DESCRIPTION
(not WIP anymore because I added unit tests)

- Open multiple connections per MX record, depending on the priority of the
  record and the number of connections we have configured in the config, based on
  the percentage difference between each greater priority compared to the lowest/initial priority

- Eg, if we have 2 connections per MX record set in config, and we have 5 MX records
  with the same priority, we will have 2 connections per each of those 5 MX records

- If we have two MX records, one priority of 10 and the other priority of 20, with 2
  connections per record set in config, the first MX record will have 2 connections and
  the second will have 1 connection (as 10 is half the size of 20).

- Periodically, whenever MX record TTL expires and the new result is different, regenerate
  the connection pool with recalculated counts of connections per each node and closing old 
  connections