### PR TITLE
Rollback to old smtp vendor behavior

### DIFF
--- a/test/test_iris_vendor_smtp.py
+++ b/test/test_iris_vendor_smtp.py
@@ -42,16 +42,7 @@ def test_smtp_send_email(mocker):
         ['iris@bar'],
         ['foo@bar'],
         CheckEmailString())
-
-    mocked_SMPT.reset_mock()
-
-    smtp_vendor.send_email({
-        'destination': 'foo@bar',
-        'subject': 'hello',
-        'body': 'world',
-    })
-
-    mocked_SMPT.assert_not_called()
+    mocked_SMPT.return_value.quit.assert_called_once_with()
 
 
 def test_smtp_unicode(mocker):


### PR DESCRIPTION
Revert previous attempt of sharing a single connection across all gevent workers as we now know that this does not work.