### PR TITLE
Make each worker have its own instances of vendors

### DIFF
--- a/src/iris/applications/dummy_app.py
+++ b/src/iris/applications/dummy_app.py
@@ -2,5 +2,11 @@ class dummy_app(object):
     name = 'dummy app'
 
     def __init__(self, vendor):
-        vendor.time_taken = 2
-        self.send = vendor.send
+        self.vendor = vendor
+
+        # Contrived example of how a sample application can change how a
+        # message is sent
+        self.time_taken = 2
+
+    def send(self, message):
+        return self.vendor.send(message, {'time_taken': self.time_taken})

--- a/src/iris/vendors/__init__.py
+++ b/src/iris/vendors/__init__.py
@@ -9,61 +9,62 @@ import random
 import copy
 logger = logging.getLogger(__name__)
 
-_max_tries_per_message = 5
-_vendors_iter = {}
-_app_specific_vendors_iter = defaultdict(dict)
-
 
 class IrisVendorException(Exception):
     pass
 
 
-def init_vendors(vendors, application_vendors):
-    applications = {}
+class IrisVendorManager():
 
-    for application in application_vendors:
-        try:
-            application_cls = import_custom_module('iris.applications', application)
-        except ImportError:
-            logger.exception('Failed importing application %s', application)
-            continue
+    def __init__(self, vendors, application_vendors):
+        self.max_tries_per_message = 5
+        self.vendors_iter = {}
+        self.app_specific_vendors_iter = defaultdict(dict)
 
-        try:
-            applications[application_cls.name] = application_cls
-        except AttributeError:
-            logger.exception('Failed loading name of custom application %s', application)
-            continue
+        applications = {}
 
-    vendor_instances = defaultdict(list)
-    app_vendor_instances = defaultdict(lambda: defaultdict(list))
-    for vendor_config in vendors:
-        vendor_cls = import_custom_module('iris.vendors', vendor_config['type'])
-        for mode in vendor_cls.supports:
-            vendor_instances[mode].append(vendor_cls(copy.deepcopy(vendor_config)))
-            for application_name, application_cls in applications.iteritems():
-                app_vendor_instances[application_name][mode].append(application_cls(vendor_cls(copy.deepcopy(vendor_config))))
+        for application in application_vendors:
+            try:
+                application_cls = import_custom_module('iris.applications', application)
+            except ImportError:
+                logger.exception('Failed importing application %s', application)
+                continue
 
-    for mode, instances in vendor_instances.iteritems():
-        random.shuffle(instances)
-        _vendors_iter[mode] = itertools.cycle(instances)
+            try:
+                applications[application_cls.name] = application_cls
+            except AttributeError:
+                logger.exception('Failed loading name of custom application %s', application)
+                continue
 
-    for application_name, modes in app_vendor_instances.iteritems():
-        for mode_name, instances in modes.iteritems():
+        vendor_instances = defaultdict(list)
+        app_vendor_instances = defaultdict(lambda: defaultdict(list))
+        for vendor_config in vendors:
+            vendor_cls = import_custom_module('iris.vendors', vendor_config['type'])
+            for mode in vendor_cls.supports:
+                vendor_instance = vendor_cls(copy.deepcopy(vendor_config))
+                vendor_instances[mode].append(vendor_instance)
+                for application_name, application_cls in applications.iteritems():
+                    app_vendor_instances[application_name][mode].append(application_cls(vendor_instance))
+
+        for mode, instances in vendor_instances.iteritems():
             random.shuffle(instances)
-            _app_specific_vendors_iter[application_name][mode_name] = itertools.cycle(instances)
-        logger.info('Initialized application %s', application_name)
+            self.vendors_iter[mode] = itertools.cycle(instances)
 
+        for application_name, modes in app_vendor_instances.iteritems():
+            for mode_name, instances in modes.iteritems():
+                random.shuffle(instances)
+                self.app_specific_vendors_iter[application_name][mode_name] = itertools.cycle(instances)
 
-def send_message(message):
-    for tries, vendor in enumerate(_app_specific_vendors_iter.get(message.get('application'), _vendors_iter)[message['mode']]):
-        if tries > _max_tries_per_message:
-            logger.warning('Exhausted %d tries for message %s', tries, message)
-            break
-        logger.debug('Attempting %s send using vendor %s', message['mode'], vendor)
-        try:
-            return vendor.send(message)
-        except Exception:
-            logger.exception('Sending %s with vendor %s failed', message, vendor)
-            continue
+    def send_message(self, message):
+        for tries, vendor in enumerate(self.app_specific_vendors_iter.get(message.get('application'), self.vendors_iter)[message['mode']]):
+            if tries > self.max_tries_per_message:
+                logger.warning('Exhausted %d tries for message %s', tries, message)
+                break
+            logger.debug('Attempting %s send using vendor %s', message['mode'], vendor)
+            try:
+                return vendor.send(message)
+            except Exception:
+                logger.exception('Sending %s with vendor %s failed', message, vendor)
+                continue
 
-    raise IrisVendorException('All %s vendors failed for %s' % (message['mode'], message))
+        raise IrisVendorException('All %s vendors failed for %s' % (message['mode'], message))

--- a/src/iris/vendors/iris_dummy.py
+++ b/src/iris/vendors/iris_dummy.py
@@ -13,9 +13,13 @@ class iris_dummy(object):
     def __init__(self, config):
         self.time_taken = 1
 
-    def send(self, message):
+    def send(self, message, customizations=None):
+        if isinstance(customizations, dict):
+            time_taken = customizations.get('time_taken', self.time_taken)
+        else:
+            time_taken = self.time_taken
         if 'email_subject' in message:
             logger.info('SEND: %(destination)s %(email_subject)s', message)
         else:
             logger.info('SEND: %(mode)s %(application)s %(destination)s %(subject).25s', message)
-        return self.time_taken
+        return time_taken

--- a/src/iris/vendors/iris_slack.py
+++ b/src/iris/vendors/iris_slack.py
@@ -103,5 +103,5 @@ class iris_slack(object):
         except Exception:
             logger.exception('Slack post request failed')
 
-    def send(self, message):
+    def send(self, message, customizations=None):
         return self.modes[message['mode']](message)

--- a/src/iris/vendors/iris_smtp.py
+++ b/src/iris/vendors/iris_smtp.py
@@ -43,9 +43,13 @@ class iris_smtp(object):
         else:
             raise ValueError('Missing SMTP config for sender')
 
-    def send_email(self, message):
+    def send_email(self, message, customizations=None):
         md = markdown.Markdown()
-        from_address = self.config['from']
+
+        if isinstance(customizations, dict):
+            from_address = customizations.get('from', self.config['from'])
+        else:
+            from_address = self.config['from']
 
         start = time.time()
         m = MIMEMultipart('alternative')
@@ -111,5 +115,5 @@ class iris_smtp(object):
 
         return time.time() - start
 
-    def send(self, message):
-        return self.modes[message['mode']](message)
+    def send(self, message, customizations=None):
+        return self.modes[message['mode']](message, customizations)

--- a/src/iris/vendors/iris_twilio.py
+++ b/src/iris/vendors/iris_twilio.py
@@ -139,5 +139,5 @@ class iris_twilio(object):
 
         return send_time
 
-    def send(self, message):
+    def send(self, message, customizations=None):
         return self.modes[message['mode']](message)

--- a/test/test_vendor.py
+++ b/test/test_vendor.py
@@ -1,7 +1,7 @@
-from iris.vendors import init_vendors, send_message
+from iris.vendors import IrisVendorManager
 
 
 def test_send_through_dummy():
-    init_vendors([{'type': 'iris_dummy'}], ['dummy_app'])
-    assert send_message({'mode': 'call'}) == 1
-    assert send_message({'application': 'dummy app', 'mode': 'call'}) == 2
+    vendor_manager = IrisVendorManager([{'type': 'iris_dummy'}], ['dummy_app'])
+    assert vendor_manager.send_message({'mode': 'call'}) == 1
+    assert vendor_manager.send_message({'application': 'dummy app', 'mode': 'call'}) == 2


### PR DESCRIPTION
- Each worker now initializes all of the vendors on its own,
  leading to far less shared state

- Make incident tracking emails add the tracking message to the send
  queue rather than sending the message directly.

- Each vendor's send() method now takes an optional dict for
  customizing how the message is sent, with the most common
  use case being the from address for an email. This avoids needing
  to actually modify the vendor object, leading to:

- During vendor initialization, only do one vendor object per mode,
  instead of one vendor object per application per mode

All of this will let us create one, or multiple, smtp connections
per worker without the greenlets trampling on each others' connections.