### PR TITLE
Sender fixes

### DIFF
--- a/src/iris/sender/quota.py
+++ b/src/iris/sender/quota.py
@@ -5,7 +5,6 @@ from time import time
 from gevent import spawn, sleep
 from collections import deque
 from datetime import datetime
-from iris.sender.shared import per_mode_send_queues
 import iris.cache
 from iris import metrics
 import logging
@@ -59,9 +58,10 @@ soft_quota_notification_interval = 600
 
 class ApplicationQuota(object):
 
-    def __init__(self, db, expand_targets, sender_app):
+    def __init__(self, db, expand_targets, message_send_enqueue, sender_app):
         self.db = db
         self.expand_targets = expand_targets
+        self.message_send_enqueue = message_send_enqueue
         self.iris_application = None
         if sender_app:
             self.iris_application = iris.cache.applications.get(sender_app)
@@ -269,4 +269,4 @@ class ApplicationQuota(object):
                          'If this continues, your messages will eventually be dropped on the floor and an Iris incident will be raised.\n\n'
                          'Regards,\nIris') % (username, application, limit, duration, )
             }
-            per_mode_send_queues['email'].put(message)
+            self.message_send_enqueue(message)

--- a/test/test_sender.py
+++ b/test/test_sender.py
@@ -346,7 +346,7 @@ def test_quotas(mocker):
                  )])
     mocker.patch('iris.sender.quota.ApplicationQuota.notify_incident')
     mocker.patch('iris.sender.quota.ApplicationQuota.notify_target')
-    quotas = ApplicationQuota(None, None, None)
+    quotas = ApplicationQuota(None, None, None, None)
     sleep(1)
     assert quotas.allow_send({'application': 'testapp'})
     assert quotas.allow_send({'application': 'testapp'})


### PR DESCRIPTION
- Avoid exception while queueing incident creation emails by not
  running them through set_target_contact, which would raise a KeyError
  as they don't have a target set (and instead have destination)

- Avoid exception while sending incident tracking messages caused by
  a KeyError while trying to get the `application` key out of the message
  dict and these messages have no application

- Avoid exception while sending quota breach messages by queueing them
  using the enqueue function which results in their `destination`
  field being set, avoiding a KeyError