### PR TITLE
Avoid problems during sender shutdown

### DIFF
--- a/src/iris/coordinator/kazoo.py
+++ b/src/iris/coordinator/kazoo.py
@@ -155,6 +155,12 @@ class Coordinator(object):
                 logger.info('Releasing lock')
                 self.lock.release()
 
+        # Make us not the master
+        self.is_master = False
+
+        # Avoid sending metrics that we are still the master when we're not
+        metrics.set('is_master_sender', 0)
+
     def event_listener(self, state):
         if state == KazooState.LOST or state == KazooState.SUSPENDED:
             logger.info('ZK state transitioned to %s. Resetting master status.', state)

--- a/src/iris/sender/rpc.py
+++ b/src/iris/sender/rpc.py
@@ -18,6 +18,7 @@ access_logger = logging.getLogger('RPC:access')
 
 send_funcs = {}
 rpc_timeout = None
+rpc_server = None
 
 
 def msgpack_handle_sets(obj):
@@ -183,13 +184,22 @@ def handle_api_request(socket, address):
 
 
 def run(sender_config):
+    global rpc_server
     try:
-        StreamServer((sender_config['host'], sender_config['port']),
-                     handle_api_request).start()
+        rpc_server = StreamServer((sender_config['host'], sender_config['port']),
+                                  handle_api_request)
+        rpc_server.start()
         return True
     except Exception:
         logger.exception('Failed binding to sender RPC port')
         return False
+
+
+def shutdown():
+    global rpc_server
+    if rpc_server:
+        logger.info('Stopping RPC server')
+        rpc_server.close()
 
 
 def init(sender_config, _send_funcs):


### PR DESCRIPTION
As we now wait for in-flight messages to finish sending before shutting down
the sender, this leaves open the possibility for master status not being relinquished,
the RPC server still accepting new messages, and other potential problems like respawning
the selfkilled workers.