### PR TITLE
Add some message-dedupe to the send queues

### DIFF
--- a/test/test_sender.py
+++ b/test/test_sender.py
@@ -246,7 +246,8 @@ def test_no_valid_modes(mocker):
     mocker.patch('iris.bin.sender.set_target_contact').return_value = False
     mock_mark_message_no_contact = mocker.patch('iris.bin.sender.mark_message_has_no_contact')
     mock_mark_message_no_contact.reset_mock()
-    from iris.bin.sender import message_send_enqueue
+    from iris.bin.sender import message_send_enqueue, message_ids_being_sent
+    message_ids_being_sent.clear()
 
     message_send_enqueue(fake_message)
     mock_mark_message_no_contact.assert_called_once()


### PR DESCRIPTION
Maintain a local set of all currently queued message IDs, and don't requeue messages with
an ID that are currently in the queue.

As this set is local per-sender/slave, it will only prevent messages that are taking a *long*
time to send from being sent twice if the same ID hits the same sender more than once. Eg if
we have two slaves, at most a message will be sent twice (one per slave) but subsequent messages
will not be sent as both of those slaves will have the message ID in their set.

We could use zookeeper for a dedupe functionality to be maintained across the masters and slaves,
but that would entail significant additional usage on our ZK cluster which might not be
ideal.