### PR TITLE
sort the incident context

### DIFF
--- a/src/iris/ui/static/js/iris.js
+++ b/src/iris/ui/static/js/iris.js
@@ -1368,6 +1368,15 @@ iris = {
     init: function(){
       var location = window.location.pathname.split('/'),
           path = this.data.id = location[location.length - 1];
+
+      Handlebars.registerHelper('eachSorted', function(context, options) {
+        var ret = "";
+        Object.keys(context).sort().forEach(function(key) {
+          ret = ret + options.fn({key: key, value: context[key]});
+        })
+        return ret;
+      });
+
       this.getIncident(path);
     },
     events: function(){

--- a/src/iris/ui/templates/incident.html
+++ b/src/iris/ui/templates/incident.html
@@ -37,18 +37,18 @@
       {{#> context_template}}
         <label><strong>Context:</strong></label>
         <table id="context-table">
-          {{#each context}}
+          {{#eachSorted context}}
             {{#if this}}
             <tr>
               <td class="context-label">
-                <strong>{{@key}}:</strong>
+                <strong>{{key}}:</strong>
               </td>
               <td class="context-data">
-                {{this}}
+                {{value}}
               </td>
             </tr>
           {{/if}}
-          {{/each}}
+          {{/eachSorted}}
         </table>
       {{/context_template}}
     </div>


### PR DESCRIPTION
While integrating alertmanager, I noticed that having many context fields results in a very messy view of the incident. Sort to be more pleasing on the eye.