### PR TITLE
Add commands to fill in the gaps

### DIFF
--- a/ops/packer/README.md
+++ b/ops/packer/README.md
@@ -4,7 +4,8 @@ Build steps
 Generate JSON for packer:
 
 ```bash
-python gen_packer_cfg.py ./iris.yaml
+mkdir output
+python gen_packer_cfg.py ./iris.yaml | tail -n +2 > ./output/iris.json
 ```
 
 Build and publish AWS AMI:


### PR DESCRIPTION
The output directory needs to be created manually, but was unmentioned.
Also, use tail to remove the invalid json caused by gen_packer_cfg.py outputting an informative message