### PR TITLE
Validate username + show login errors on login form

### DIFF
--- a/src/iris/ui/auth/__init__.py
+++ b/src/iris/ui/auth/__init__.py
@@ -1,6 +1,8 @@
 # Copyright (c) LinkedIn Corporation. All rights reserved. Licensed under the BSD-2 Clause license.
 # See LICENSE in the project root for license information.
 
+from iris import db
+
 
 def login_user(req, username):
     session = req.env['beaker.session']
@@ -12,3 +14,17 @@ def logout_user(req):
     session = req.env['beaker.session']
     session.pop('user', None)
     session.delete()
+
+
+def valid_username(username):
+    connection = db.engine.raw_connection()
+    cursor = connection.cursor()
+    cursor.execute('''
+    SELECT EXISTS(SELECT 1
+                  FROM `target`
+                  JOIN `user` on `target`.`id` = `user`.`target_id`
+                  WHERE `name` = %s AND `type_id` = (SELECT `id` FROM `target_type` WHERE `name` = "user"))''', username)
+    result = cursor.fetchone()
+    cursor.close()
+    connection.close()
+    return result[0] == 1

--- a/src/iris/ui/static/css/iris.css
+++ b/src/iris/ui/static/css/iris.css
@@ -154,7 +154,7 @@ header[data-page="error"] {
 .floating-module .module {
   position: relative;
   width: 250px;
-  height: 300px;
+  min-height: 300px;
   top: 45%;
   margin: auto;
   margin-top: -200px;

--- a/src/iris/ui/templates/login.html
+++ b/src/iris/ui/templates/login.html
@@ -7,6 +7,9 @@
       <p>Iris</p>
     </div>
     <form method="POST">
+       {% if last_flash %}
+       <div class="alert alert-{{ last_flash.type }}">{{ last_flash.message }}</div>
+       {% endif %}
       <input class="form-control border-bottom" name="username" type="text" placeholder="Username" autofocus>
       <input class="form-control border-bottom" name="password" type="password" placeholder="Password">
       <button class="form-control btn btn-primary">login</button>


### PR DESCRIPTION
- Add "flashing", where we add a single message/alert to the session and it
  then persists, and gets removed when the page is loaded again

- When you try to login with an invalid username, say so if we're in debug
  mode, but give a vague error if we're in prod mode, to prevent people
  guessing valid usernames

- When you try to login with bad credentials, say that instead of refreshing
  the page and not saying anything.

Addresses https://github.com/linkedin/iris/issues/309