### PR TITLE
Reset metrics only updated by master senders

### DIFF
--- a/src/iris/bin/sender.py
+++ b/src/iris/bin/sender.py
@@ -266,7 +266,8 @@ default_sender_metrics = {
     'msg_drop_length_cnt': 0, 'send_queue_gets_cnt': 0, 'send_queue_puts_cnt': 0,
     'send_queue_email_size': 0, 'send_queue_im_size': 0, 'send_queue_slack_size': 0, 'send_queue_call_size': 0,
     'send_queue_sms_size': 0, 'send_queue_drop_size': 0, 'new_incidents_cnt': 0, 'workers_respawn_cnt': 0,
-    'message_retry_cnt': 0, 'message_ids_being_sent_cnt': 0
+    'message_retry_cnt': 0, 'message_ids_being_sent_cnt': 0, 'notifications': 0, 'deactivation': 0,
+    'new_msg_count': 0, 'poll': 0, 'queue': 0, 'aggregations': 0
 }
 
 # TODO: make this configurable

--- a/src/iris/bin/sender.py
+++ b/src/iris/bin/sender.py
@@ -1478,16 +1478,6 @@ def init_sender(config):
                                   slaves=config['sender'].get('slaves', []))
 
 
-def reset_master_only_metrics():
-    metrics.set('new_incidents_cnt', 0)
-    metrics.set('notifications', 0)
-    metrics.set('deactivation', 0)
-    metrics.set('new_msg_count', 0)
-    metrics.set('poll', 0)
-    metrics.set('queue', 0)
-    metrics.set('aggregations', 0)
-
-
 def main():
     global config
     global shutdown_started
@@ -1571,9 +1561,6 @@ def main():
             if bool(prune_audit_logs_task):
                 logger.info('I am not master anymore so stopping the audit logs worker')
                 prune_audit_logs_task.kill()
-            # If we were counting on the metrics which were updated only in master,
-            # we should reset it
-            reset_master_only_metrics()
 
         # check status for all background greenlets and respawn if necessary
         if not bool(send_task):

--- a/src/iris/bin/sender.py
+++ b/src/iris/bin/sender.py
@@ -1477,6 +1477,16 @@ def init_sender(config):
                                   slaves=config['sender'].get('slaves', []))
 
 
+def reset_master_only_metrics():
+    metrics.set('new_incidents_cnt', 0)
+    metrics.set('notifications', 0)
+    metrics.set('deactivation', 0)
+    metrics.set('new_msg_count', 0)
+    metrics.set('poll', 0)
+    metrics.set('queue', 0)
+    metrics.set('aggregations', 0)
+
+
 def main():
     global config
     global shutdown_started
@@ -1560,6 +1570,9 @@ def main():
             if bool(prune_audit_logs_task):
                 logger.info('I am not master anymore so stopping the audit logs worker')
                 prune_audit_logs_task.kill()
+            # If we were counting on the metrics which were updated only in master,
+            # we should reset it
+            reset_master_only_metrics()
 
         # check status for all background greenlets and respawn if necessary
         if not bool(send_task):


### PR DESCRIPTION
Sometimes, alerting systems depend on metrics from the master node.
It's better to not emit those metrics or emit a zero value if the current node is not master