### PR TITLE
Use SSDictCursor for queries that have very large responses

### DIFF
--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -1065,7 +1065,7 @@ class Plans(object):
         if query_limit is not None:
             query += ' ORDER BY `plan`.`created` DESC LIMIT %s' % query_limit
 
-        cursor = connection.cursor(db.dict_cursor)
+        cursor = connection.cursor(db.ss_dict_cursor)
         cursor.execute(query)
 
         payload = ujson.dumps(cursor)
@@ -1320,7 +1320,7 @@ class Incidents(object):
         if query_limit is not None:
             query += ' ORDER BY `incident`.`created` DESC LIMIT %s' % query_limit
 
-        cursor = connection.cursor(db.dict_cursor)
+        cursor = connection.cursor(db.ss_dict_cursor)
         cursor.execute(query, sql_values)
 
         if 'context' in fields:
@@ -1687,7 +1687,7 @@ class Messages(object):
 
         if query_limit is not None:
             query += ' ORDER BY `message`.`created` DESC LIMIT %s' % query_limit
-        cursor = connection.cursor(db.dict_cursor)
+        cursor = connection.cursor(db.ss_dict_cursor)
         cursor.execute(query)
         resp.body = ujson.dumps(cursor)
         connection.close()
@@ -1954,7 +1954,7 @@ class Templates(object):
         if query_limit is not None:
             query += ' ORDER BY `template`.`created` DESC LIMIT %s' % query_limit
 
-        cursor = connection.cursor(db.dict_cursor)
+        cursor = connection.cursor(db.ss_dict_cursor)
         cursor.execute(query)
 
         payload = ujson.dumps(cursor)

--- a/src/iris/db.py
+++ b/src/iris/db.py
@@ -13,17 +13,20 @@ logger = logging.getLogger(__name__)
 
 Session = None
 dict_cursor = None
+ss_dict_cursor = None
 engine = None
 
 
 def init(config):
     global engine
     global dict_cursor
+    global ss_dict_cursor
     global Session
 
     engine = create_engine(config['db']['conn']['str'] % config['db']['conn']['kwargs'],
                            **config['db']['kwargs'])
     dict_cursor = engine.dialect.dbapi.cursors.DictCursor
+    ss_dict_cursor = engine.dialect.dbapi.cursors.SSDictCursor
     Session = sessionmaker(bind=engine)
 
 


### PR DESCRIPTION
Alleviate occasional MemoryError for queries (like incident list) which return
gigantic responses by using SSCursor which iteratively fetches the result from
the database instead of getting it all in one shot.

Docs: http://pymysql.readthedocs.io/en/latest/modules/cursors.html#pymysql.cursors.SSCursor

Helpful SO post: https://stackoverflow.com/questions/18193825/python-how-to-use-a-generator-to-avoid-sql-memory-issue