### PR TITLE
Adding metrics only updated by master to default_sender_metrics

### DIFF
--- a/src/iris/bin/sender.py
+++ b/src/iris/bin/sender.py
@@ -266,7 +266,8 @@ default_sender_metrics = {
     'msg_drop_length_cnt': 0, 'send_queue_gets_cnt': 0, 'send_queue_puts_cnt': 0,
     'send_queue_email_size': 0, 'send_queue_im_size': 0, 'send_queue_slack_size': 0, 'send_queue_call_size': 0,
     'send_queue_sms_size': 0, 'send_queue_drop_size': 0, 'new_incidents_cnt': 0, 'workers_respawn_cnt': 0,
-    'message_retry_cnt': 0, 'message_ids_being_sent_cnt': 0
+    'message_retry_cnt': 0, 'message_ids_being_sent_cnt': 0, 'notifications': 0, 'deactivation': 0,
+    'new_msg_count': 0, 'poll': 0, 'queue': 0, 'aggregations': 0
 }
 
 # TODO: make this configurable


### PR DESCRIPTION
So that they are also reset by stats_reset after each emission. 