### PR TITLE
add support for initial ldap bind user

### DIFF
--- a/src/iris/ui/auth/ldap.py
+++ b/src/iris/ui/auth/ldap.py
@@ -8,6 +8,7 @@ import os
 
 logger = logging.getLogger(__name__)
 
+
 class Authenticator:
     def __init__(self, config):
         root = os.path.abspath('./')

--- a/src/iris/ui/auth/ldap.py
+++ b/src/iris/ui/auth/ldap.py
@@ -17,7 +17,7 @@ class Authenticator:
             return
         self.authenticate = self.ldap_auth
 
-        if 'ldap_cert_path' in config:
+        if 'ldap_cert_path' in config['auth']:
             self.cert_path = os.path.join(root, config['auth']['ldap_cert_path'])
             if not os.access(self.cert_path, os.R_OK):
                 logger.error("Failed to read ldap_cert_path certificate")

--- a/src/iris/ui/auth/ldap.py
+++ b/src/iris/ui/auth/ldap.py
@@ -2,33 +2,60 @@
 # See LICENSE in the project root for license information.
 
 from __future__ import absolute_import
+import logging
 import ldap
 import os
 
+logger = logging.getLogger(__name__)
 
 class Authenticator:
     def __init__(self, config):
         root = os.path.abspath('./')
-        self.ldap_url = config['auth']['ldap_url']
-        self.cert_path = os.path.join(root, config['auth']['ldap_cert_path'])
-        self.user_suffix = config['auth']['ldap_user_suffix']
-        self.authenticate = self.ldap_auth
         if config.get('debug'):
             self.authenticate = self.debug_auth
+            return
+        self.authenticate = self.ldap_auth
+
+        if 'ldap_cert_path' in config:
+            self.cert_path = os.path.join(root, config['auth']['ldap_cert_path'])
+            if not os.access(self.cert_path, os.R_OK):
+                logger.error("Failed to read ldap_cert_path certificate")
+                raise IOError
+
+        self.bind_user = config['auth'].get('ldap_bind_user')
+        self.bind_password = config['auth'].get('ldap_bind_password')
+        self.search_filter = config['auth'].get('ldap_search_filter')
+
+        self.ldap_url = config['auth'].get('ldap_url')
+        self.base_dn = config['auth'].get('ldap_base_dn')
+
+        self.user_suffix = config['auth'].get('ldap_user_suffix')
 
     def ldap_auth(self, username, password):
         ldap.set_option(ldap.OPT_X_TLS_CACERTFILE, self.cert_path)
         connection = ldap.initialize(self.ldap_url)
         connection.set_option(ldap.OPT_REFERRALS, 0)
 
+        if not password:
+            return False
+
+        auth_user = username + self.user_suffix
         try:
-            if password:
-                connection.simple_bind_s(username + self.user_suffix, password)
-            else:
-                return False
+            if self.bind_user:
+                # use search filter to find DN of username
+                connection.simple_bind_s(self.bind_user, self.bind_password)
+                sfilter = self.search_filter % username
+                result = connection.search_s(self.base_dn, ldap.SCOPE_SUBTREE, sfilter, ['dn'])
+                if len(result) < 1:
+                    return False
+                auth_user = result[0][0]
+
+            connection.simple_bind_s(auth_user, password)
+
         except ldap.INVALID_CREDENTIALS:
             return False
-        except ldap.SERVER_DOWN:
+        except (ldap.SERVER_DOWN, ldap.INVALID_DN_SYNTAX) as err:
+            logger.warn("%s", err)
             return None
         return True
 


### PR DESCRIPTION
Allow a bind user to be specified and a search filter, to find the users actual DN, like in https://github.com/linkedin/oncall/issues/115

I'll add config examples depending on when/if https://github.com/linkedin/iris/pull/334 is merged.