### PR TITLE
Include iris ui static files in source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+recursive-include src/iris/ui/templates *
+recursive-include src/iris/ui/static *


### PR DESCRIPTION
Include iris ui template and static files when `python setup.py sdist`.
To fix error `jinja2.exceptions.TemplateNotFound`