### PR TITLE
Flake8 tweaks for issue #346

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setuptools.setup(
             'pytest==3.0.5',
             'pytest-mock==1.5.0',
             'pytest-cov',
-            'flake8',
+            'flake8==3.5.0',
             'tox',
             'requests-mock==1.1.0',
         ],

--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -1850,7 +1850,7 @@ class Notifications(object):
             s = socket.create_connection(sender_addr)
 
         # Then try slaves
-        except:
+        except Exception:
             if self.coordinator:
                 logger.exception('Failed contacting master (%s). Resorting to slaves.', sender_addr)
                 for slave_address in self.coordinator.get_current_slaves():
@@ -1858,7 +1858,7 @@ class Notifications(object):
                         logger.info('Trying slave %s..', slave_address)
                         s = socket.create_connection(slave_address)
                         break
-                    except:
+                    except Exception:
                         logger.exception('Failed reaching slave %s', slave_address)
 
         # If none of that works, bail
@@ -3646,14 +3646,14 @@ class Reprioritization(object):
         try:
             cursor.execute('SELECT `id` FROM `mode` WHERE `name` = %s', params['src_mode'])
             src_mode_id = cursor.fetchone()['id']
-        except:
+        except Exception:
             msg = 'Invalid source mode.'
             logger.exception(msg)
             raise HTTPBadRequest(msg, msg)
         try:
             cursor.execute('SELECT `id` FROM `mode` WHERE `name` = %s', params['dst_mode'])
             dst_mode_id = cursor.fetchone()['id']
-        except:
+        except Exception:
             msg = 'Invalid destination mode.'
             logger.exception(msg)
             raise HTTPBadRequest(msg, msg)
@@ -3738,7 +3738,7 @@ class Healthcheck(object):
         try:
             with open(self.healthcheck_path) as f:
                 health = f.readline().strip()
-        except:
+        except Exception:
             raise HTTPNotFound()
         resp.status = HTTP_200
         resp.content_type = 'text/plain'

--- a/src/iris/role_lookup/__init__.py
+++ b/src/iris/role_lookup/__init__.py
@@ -19,7 +19,7 @@ def get_role_lookups(config):
             imported_modules.append(
                 import_custom_module('iris.role_lookup', m)(config))
             logger.info('Loaded lookup modules: %s', m)
-        except:
+        except Exception:
             logger.exception('Failed to load role lookup module: %s', m)
 
     return imported_modules

--- a/src/iris/sender/cache.py
+++ b/src/iris/sender/cache.py
@@ -447,7 +447,7 @@ def init(api_host, config):
             re = iris_client.get('target_roles')
             if re.status_code == 200:
                 break
-        except:
+        except Exception:
             pass
         api_chk_cnt += 1
         logger.warning(

--- a/src/iris/sphinx_extension.py
+++ b/src/iris/sphinx_extension.py
@@ -32,7 +32,7 @@ def get_routes(app):
                     if handler.__getattribute__('func_name') == 'method_not_allowed':
                         # method not defined for route
                         continue
-                except:
+                except Exception:
                     pass
                 yield method, curr_node.uri_template, handler
 

--- a/src/iris/vendors/iris_smtp.py
+++ b/src/iris/vendors/iris_smtp.py
@@ -145,7 +145,7 @@ class iris_smtp(object):
 
             try:
                 conn.quit()
-            except:
+            except Exception:
                 pass
 
             # If we can't send it, try reconnecting and then sending it one more time before
@@ -180,7 +180,7 @@ class iris_smtp(object):
             logger.info('Trying to quit smtp connection to %s', self.last_conn_server)
             try:
                 self.last_conn.quit()
-            except:
+            except Exception:
                 pass
 
     @classmethod

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = py27
 [flake8]
 exclude = .tox,./build
 filename = *.py
-ignore = E501,E101
+ignore = E501,E101,E741
 
 [testenv]
 deps =


### PR DESCRIPTION
- The default flake8 was currently bumped (as we're not pinning a
  specific version in setup.py) and it brought with it a few new style
  checks, which has been causing CircleCI builds to fail (#346)

- Fix all instances of E722 (don't use bare except:)

- Ignore E741 (single letter variable names)

- Pin flake8 to this new version in setup.py so we don't hit another
  change