### PR TITLE
do not log information about setting prometheus metrics

### DIFF
--- a/src/iris/metrics/prometheus.py
+++ b/src/iris/metrics/prometheus.py
@@ -34,6 +34,5 @@ class prometheus(object):
         for metric, value in metrics.iteritems():
             if metric not in self.gauges:
                 self.gauges[metric] = Gauge(self.appname + '_' + metric, '')
-            logger.info('Setting metrics gauge %s to %s', metric, value)
             self.gauges[metric].set_to_current_time()
             self.gauges[metric].set(value)


### PR DESCRIPTION
Perhaps somewhat useful for debugging, but in most cases just noise that drowns out proper logging.