### PR TITLE
Allow disabling gwatch

### DIFF
--- a/configs/config.dev.yaml
+++ b/configs/config.dev.yaml
@@ -82,9 +82,6 @@ sender:
   # Disable the gmail based iris-sender watchdog process
   disable_gwatch_renewer_task: True
 
-  # Enable this and the above setting, to mock gwatch_renewer
-  #mock_gwatch_renewer_task: False
-
   ## If you're not using zookeeper, the following determines
   ## whether this sender is a master and you hard code in
   ## slaves to be cycled through

--- a/configs/config.dev.yaml
+++ b/configs/config.dev.yaml
@@ -80,7 +80,7 @@ sender:
   #zookeeper_cluster: localhost:2181
 
   # Disable the gmail based iris-sender watchdog process
-  disable_gwatch_renewer_task: True
+  disable_gwatch_renewer: True
 
   ## If you're not using zookeeper, the following determines
   ## whether this sender is a master and you hard code in

--- a/configs/config.dev.yaml
+++ b/configs/config.dev.yaml
@@ -79,6 +79,12 @@ sender:
   ## Optionally, use zookeeper for sender high availability.
   #zookeeper_cluster: localhost:2181
 
+  # Disable the gmail based iris-sender watchdog process
+  disable_gwatch_renewer_task: True
+
+  # Enable this and the above setting, to mock gwatch_renewer
+  #mock_gwatch_renewer_task: False
+
   ## If you're not using zookeeper, the following determines
   ## whether this sender is a master and you hard code in
   ## slaves to be cycled through

--- a/src/iris/bin/sender.py
+++ b/src/iris/bin/sender.py
@@ -1504,7 +1504,8 @@ def main():
 
     maintain_workers(config)
 
-    gwatch_renewer_task = config['sender'].get('disable_gwatch_renewer_task', False)
+    disable_gwatch_renewer = config['sender'].get('disable_gwatch_renewer_task', False)
+    gwatch_renewer_task = None
     prune_audit_logs_task = None
 
     interval = 60
@@ -1528,7 +1529,7 @@ def main():
         # If we're currently a master, ensure our master-greenlets are running
         # and we're doing the master duties
         if coordinator.am_i_master():
-            if not bool(gwatch_renewer_task):
+            if not bool(gwatch_renewer_task) and not disable_gwatch_renewer:
                 if should_mock_gwatch_renewer:
                     gwatch_renewer_task = spawn(mock_gwatch_renewer)
                 else:

--- a/src/iris/bin/sender.py
+++ b/src/iris/bin/sender.py
@@ -1504,7 +1504,7 @@ def main():
 
     maintain_workers(config)
 
-    disable_gwatch_renewer = config['sender'].get('disable_gwatch_renewer_task', False)
+    disable_gwatch_renewer = config['sender'].get('disable_gwatch_renewer', False)
     gwatch_renewer_task = None
     prune_audit_logs_task = None
 

--- a/src/iris/bin/sender.py
+++ b/src/iris/bin/sender.py
@@ -1449,7 +1449,7 @@ def init_sender(config):
         should_skip_send = True
     else:
         should_skip_send = False
-    should_mock_gwatch_renewer = should_mock_gwatch_renewer or config['sender'].get('mock_gwatch_renewer_task', False)
+    should_mock_gwatch_renewer = should_mock_gwatch_renewer or config['sender'].get('skipgmailwatch', False)
     should_skip_send = should_skip_send or config.get('skipsend', False)
 
     if should_skip_send:

--- a/src/iris/bin/sender.py
+++ b/src/iris/bin/sender.py
@@ -1449,7 +1449,7 @@ def init_sender(config):
         should_skip_send = True
     else:
         should_skip_send = False
-    should_mock_gwatch_renewer = should_mock_gwatch_renewer or config.get('skipgmailwatch', False)
+    should_mock_gwatch_renewer = should_mock_gwatch_renewer or config['sender'].get('mock_gwatch_renewer', False)
     should_skip_send = should_skip_send or config.get('skipsend', False)
 
     if should_skip_send:
@@ -1504,7 +1504,7 @@ def main():
 
     maintain_workers(config)
 
-    gwatch_renewer_task = None
+    gwatch_renewer_task = config['sender'].get('disable_gwatch_renewer_task', False)
     prune_audit_logs_task = None
 
     interval = 60

--- a/src/iris/bin/sender.py
+++ b/src/iris/bin/sender.py
@@ -1449,7 +1449,7 @@ def init_sender(config):
         should_skip_send = True
     else:
         should_skip_send = False
-    should_mock_gwatch_renewer = should_mock_gwatch_renewer or config['sender'].get('mock_gwatch_renewer', False)
+    should_mock_gwatch_renewer = should_mock_gwatch_renewer or config['sender'].get('mock_gwatch_renewer_task', False)
     should_skip_send = should_skip_send or config.get('skipsend', False)
 
     if should_skip_send:

--- a/src/iris/bin/sender.py
+++ b/src/iris/bin/sender.py
@@ -1529,7 +1529,7 @@ def main():
         # If we're currently a master, ensure our master-greenlets are running
         # and we're doing the master duties
         if coordinator.am_i_master():
-            if not bool(gwatch_renewer_task) and not disable_gwatch_renewer:
+            if not disable_gwatch_renewer and not bool(gwatch_renewer_task):
                 if should_mock_gwatch_renewer:
                     gwatch_renewer_task = spawn(mock_gwatch_renewer)
                 else:

--- a/src/iris/bin/sender.py
+++ b/src/iris/bin/sender.py
@@ -1449,7 +1449,7 @@ def init_sender(config):
         should_skip_send = True
     else:
         should_skip_send = False
-    should_mock_gwatch_renewer = should_mock_gwatch_renewer or config['sender'].get('skipgmailwatch', False)
+    should_mock_gwatch_renewer = should_mock_gwatch_renewer or config.get('skipgmailwatch', False)
     should_skip_send = should_skip_send or config.get('skipsend', False)
 
     if should_skip_send:

--- a/test/test_sender.py
+++ b/test/test_sender.py
@@ -45,7 +45,7 @@ def test_configure(mocker):
         },
         'sender': {
             'debug': True,
-            'mock_gwatch_renewer': True,
+            'mock_gwatch_renewer_task': True,
         },
         'oncall': 'http://localhost:8002',
         'role_lookup': 'dummy',

--- a/test/test_sender.py
+++ b/test/test_sender.py
@@ -45,12 +45,12 @@ def test_configure(mocker):
         },
         'sender': {
             'debug': True,
+            'mock_gwatch_renewer': True,
         },
         'oncall': 'http://localhost:8002',
         'role_lookup': 'dummy',
         'metrics': 'dummy',
         'skipsend': True,
-        'skipgmailwatch': True,
     })
 
 

--- a/test/test_sender.py
+++ b/test/test_sender.py
@@ -45,7 +45,7 @@ def test_configure(mocker):
         },
         'sender': {
             'debug': True,
-            'mock_gwatch_renewer_task': True,
+            'skipgmailwatch': True,
         },
         'oncall': 'http://localhost:8002',
         'role_lookup': 'dummy',


### PR DESCRIPTION
- Allow disabling gwatch by introducing config['sender']['disable_gwatch_renewer_task']. False if left unconfigured to retain behavior in existing setups
- Rename config['skipgmailwatch'] to config['sender']['mock_gwatch_renewer_task'], to better reflect its behavior
- Document both variables and set "disable_gwatch_renewer_task: True" so newcomers get a better default

https://github.com/linkedin/iris/issues/360