### PR TITLE
allow notification to room and add hipchat metrics

### DIFF
--- a/configs/config.dev.yaml
+++ b/configs/config.dev.yaml
@@ -136,7 +136,11 @@ vendors: []
 
 ## Hipchat support requires adding a new mode called "hipchat", in iris' mode table
 ## Also, uncomment the hipchat workers to the sender['workers_per_mode'] hash above
-## Messages will be sent to $room_id with $username getting a mention.
+## Messages will be sent to $room_id by default, with @UserName getting a mention
+## Note that we support 3 different values for a users hipchat value:
+## 1. @UserName
+## 2. room_id;token
+## 3. room_id;token;@UserName
 #- type: iris_hipchat
 #  name: hipchat
 #  auth_token: 'mytoken'

--- a/src/iris/bin/sender.py
+++ b/src/iris/bin/sender.py
@@ -267,7 +267,7 @@ default_sender_metrics = {
     'send_queue_email_size': 0, 'send_queue_im_size': 0, 'send_queue_slack_size': 0, 'send_queue_call_size': 0,
     'send_queue_sms_size': 0, 'send_queue_drop_size': 0, 'new_incidents_cnt': 0, 'workers_respawn_cnt': 0,
     'message_retry_cnt': 0, 'message_ids_being_sent_cnt': 0, 'notifications': 0, 'deactivation': 0,
-    'new_msg_count': 0, 'poll': 0, 'queue': 0, 'aggregations': 0, 'hipchat_cnt': 0,'hipchat_fail': 0,
+    'new_msg_count': 0, 'poll': 0, 'queue': 0, 'aggregations': 0, 'hipchat_cnt': 0, 'hipchat_fail': 0,
     'hipchat_total': 0, 'hipchat_sent': 0, 'hipchat_max': 0, 'hipchat_min': 0
 }
 

--- a/src/iris/bin/sender.py
+++ b/src/iris/bin/sender.py
@@ -267,7 +267,8 @@ default_sender_metrics = {
     'send_queue_email_size': 0, 'send_queue_im_size': 0, 'send_queue_slack_size': 0, 'send_queue_call_size': 0,
     'send_queue_sms_size': 0, 'send_queue_drop_size': 0, 'new_incidents_cnt': 0, 'workers_respawn_cnt': 0,
     'message_retry_cnt': 0, 'message_ids_being_sent_cnt': 0, 'notifications': 0, 'deactivation': 0,
-    'new_msg_count': 0, 'poll': 0, 'queue': 0, 'aggregations': 0
+    'new_msg_count': 0, 'poll': 0, 'queue': 0, 'aggregations': 0, 'hipchat_cnt': 0,'hipchat_fail': 0,
+    'hipchat_total': 0, 'hipchat_sent': 0, 'hipchat_max': 0, 'hipchat_min': 0
 }
 
 # TODO: make this configurable

--- a/src/iris/vendors/iris_hipchat.py
+++ b/src/iris/vendors/iris_hipchat.py
@@ -24,7 +24,7 @@ class iris_hipchat(object):
             self.proxy = {'http': 'http://%s:%s' % (host, port),
                           'https': 'https://%s:%s' % (host, port)}
         self.token = self.config.get('auth_token')
-        self.room_id = self.config.get('room_id')
+        self.room_id = int(self.config.get('room_id'))
         self.debug = self.config.get('debug')
         self.endpoint_url = self.config.get('base_url')
 

--- a/src/iris/vendors/iris_hipchat.py
+++ b/src/iris/vendors/iris_hipchat.py
@@ -74,7 +74,7 @@ class iris_hipchat(object):
             else:
                 logger.error("Invalid destination: %s. Contains %s fields.", destination, len(dparts))
         else:
-                logger.error("Invalid destination: %s. Neither @user or ; separated value.", destination)
+            logger.error("Invalid destination: %s. Neither @user or ; separated value.", destination)
 
         return room_id, token, mention
 

--- a/src/iris/vendors/iris_hipchat.py
+++ b/src/iris/vendors/iris_hipchat.py
@@ -47,8 +47,8 @@ class iris_hipchat(object):
         """Determine room_id, token and user to mention
            We accept 3 formats:
              - Just a mention (@testuser)
-             - Room_id and Token (12341:a20asdfgjahdASDfaskw)
-             - Room_id, Token and mention (12341:a20asdfgjahdASDfaskw;@testuser)
+             - Room_id and Token (12341;a20asdfgjahdASDfaskw)
+             - Room_id, Token and mention (12341;a20asdfgjahdASDfaskw;@testuser)
         """
         room_id = self.room_id
         token = self.token
@@ -68,15 +68,15 @@ class iris_hipchat(object):
                 mention = dparts[2]
             elif len(dparts) == 2:
                 try:
-                    int(dparts[0])
-                    room_id = dparts[0]
+                    room_id = int(dparts[0])
                 except ValueError:
+                    logger.error("Invalid destination: %s. Using default room_id", destination)
                     pass
                 token = dparts[1]
             else:
-                logger.error("Invalid destination: %s", destination)
+                logger.error("Invalid destination: %s. Contains %s fields.", destination, len(dparts))
         else:
-                logger.error("Invalid destination: %s", destination)
+                logger.error("Invalid destination: %s. Neither @user or ; separated value.", destination)
 
         return room_id, token, mention
 

--- a/src/iris/vendors/iris_hipchat.py
+++ b/src/iris/vendors/iris_hipchat.py
@@ -60,10 +60,9 @@ class iris_hipchat(object):
             dparts = destination.split(";")
             if len(dparts) == 3:
                 try:
-                    int(dparts[0])
-                    room_id = dparts[0]
+                    room_id = int(dparts[0])
                 except ValueError:
-                    pass
+                    logger.error("Invalid destination: %s. Using default room_id", destination)
                 token = dparts[1]
                 mention = dparts[2]
             elif len(dparts) == 2:
@@ -71,7 +70,6 @@ class iris_hipchat(object):
                     room_id = int(dparts[0])
                 except ValueError:
                     logger.error("Invalid destination: %s. Using default room_id", destination)
-                    pass
                 token = dparts[1]
             else:
                 logger.error("Invalid destination: %s. Contains %s fields.", destination, len(dparts))

--- a/test/test_iris_vendor_hipchat.py
+++ b/test/test_iris_vendor_hipchat.py
@@ -7,14 +7,15 @@ from iris.vendors.iris_hipchat import iris_hipchat
 def test_message_construction_for_incident():
     hipchat_vendor = iris_hipchat({
         'auth_token': 'abc',
-        'iris_incident_url': 'http://foo.bar/incidents'
+        'iris_incident_url': 'http://foo.bar/incidents',
+        'room_id': 1234,
     })
     fake_msg = {
         'application': 'grafana',
         'incident_id': 123,
         'body': u'test body',
         'message_id': 456,
-        'destination': '@user1'
+        'destination': '@user1',
     }
     msg_payload = hipchat_vendor.get_message_payload(fake_msg, "@user1")
     assert msg_payload['message'] == '@user1 %s' % fake_msg['body']
@@ -23,7 +24,8 @@ def test_message_construction_for_incident():
 def test_destination_parsing_for_incident():
     hipchat_vendor = iris_hipchat({
         'auth_token': 'abc',
-        'iris_incident_url': 'http://foo.bar/incidents'
+        'iris_incident_url': 'http://foo.bar/incidents',
+        'room_id': 1234,
     })
     fake_msg = {
         'application': 'grafana',
@@ -34,14 +36,16 @@ def test_destination_parsing_for_incident():
     destination = '1234;testtoken;@user1'
     fake_msg['destination'] = destination
     room_id, token, mention = hipchat_vendor.parse_destination(fake_msg['destination'])
-    assert room_id == '1234'
+
+    assert room_id == 1234
     assert token == 'testtoken'
     assert mention == '@user1'
 
     destination = '1234;testtoken'
     fake_msg['destination'] = destination
     room_id, token, mention = hipchat_vendor.parse_destination(fake_msg['destination'])
-    assert room_id == '1234'
+
+    assert room_id == 1234
     assert token == 'testtoken'
     assert mention == ''
 
@@ -50,7 +54,7 @@ def test_destination_parsing_defaults_for_incident():
     hipchat_vendor = iris_hipchat({
         'auth_token': 'validtoken',
         'iris_incident_url': 'http://foo.bar/incidents',
-        'room_id': '1234',
+        'room_id': 1234,
     })
     fake_msg = {
         'application': 'grafana',
@@ -61,13 +65,15 @@ def test_destination_parsing_defaults_for_incident():
     destination = 'user_missing_@'
     fake_msg['destination'] = destination
     room_id, token, mention = hipchat_vendor.parse_destination(fake_msg['destination'])
-    assert room_id == '1234'
+
+    assert room_id == 1234
     assert token == 'validtoken'
     assert mention == ''
 
     destination = 'not_an_int;testtoken'
     fake_msg['destination'] = destination
     room_id, token, mention = hipchat_vendor.parse_destination(fake_msg['destination'])
-    assert room_id == '1234'
+
+    assert room_id == 1234
     assert token == 'testtoken'
     assert mention == ''

--- a/test/test_iris_vendor_hipchat.py
+++ b/test/test_iris_vendor_hipchat.py
@@ -7,18 +7,65 @@ from iris.vendors.iris_hipchat import iris_hipchat
 def test_message_construction_for_incident():
     hipchat_vendor = iris_hipchat({
         'auth_token': 'abc',
-        'iris_incident_url': 'http://foo.bar/incidents',
-        'message_attachments': {
-            'fallback': 'foo fallback',
-            'pretext': 'foo pretext',
-        }
+        'iris_incident_url': 'http://foo.bar/incidents'
     })
     fake_msg = {
         'application': 'grafana',
         'incident_id': 123,
         'body': u'test body',
         'message_id': 456,
-        'destination': 'user1'
+        'destination': '@user1'
     }
-    msg_payload = hipchat_vendor.get_message_payload(fake_msg)
+    msg_payload = hipchat_vendor.get_message_payload(fake_msg, "@user1")
     assert msg_payload['message'] == '@user1 %s' % fake_msg['body']
+
+def test_destination_parsing_for_incident():
+    hipchat_vendor = iris_hipchat({
+        'auth_token': 'abc',
+        'iris_incident_url': 'http://foo.bar/incidents'
+    })
+    fake_msg = {
+        'application': 'grafana',
+        'incident_id': 123,
+        'body': u'test body',
+        'message_id': 456,
+    }
+    destination = '1234;testtoken;@user1'
+    fake_msg['destination'] = destination
+    room_id, token, mention = hipchat_vendor.parse_destination(fake_msg['destination'])
+    assert room_id == '1234'
+    assert token == 'testtoken'
+    assert mention == '@user1'
+
+    destination = '1234;testtoken'
+    fake_msg['destination'] = destination
+    room_id, token, mention = hipchat_vendor.parse_destination(fake_msg['destination'])
+    assert room_id == '1234'
+    assert token == 'testtoken'
+    assert mention == ''
+
+def test_destination_parsing_defaults_for_incident():
+    hipchat_vendor = iris_hipchat({
+        'auth_token': 'validtoken',
+        'iris_incident_url': 'http://foo.bar/incidents',
+        'room_id': '1234',
+    })
+    fake_msg = {
+        'application': 'grafana',
+        'incident_id': 123,
+        'body': u'test body',
+        'message_id': 456,
+    }
+    destination = 'user_missing_@'
+    fake_msg['destination'] = destination
+    room_id, token, mention = hipchat_vendor.parse_destination(fake_msg['destination'])
+    assert room_id == '1234'
+    assert token == 'validtoken'
+    assert mention == ''
+
+    destination = 'not_an_int;testtoken'
+    fake_msg['destination'] = destination
+    room_id, token, mention = hipchat_vendor.parse_destination(fake_msg['destination'])
+    assert room_id == '1234'
+    assert token == 'testtoken'
+    assert mention == ''

--- a/test/test_iris_vendor_hipchat.py
+++ b/test/test_iris_vendor_hipchat.py
@@ -19,6 +19,7 @@ def test_message_construction_for_incident():
     msg_payload = hipchat_vendor.get_message_payload(fake_msg, "@user1")
     assert msg_payload['message'] == '@user1 %s' % fake_msg['body']
 
+
 def test_destination_parsing_for_incident():
     hipchat_vendor = iris_hipchat({
         'auth_token': 'abc',
@@ -43,6 +44,7 @@ def test_destination_parsing_for_incident():
     assert room_id == '1234'
     assert token == 'testtoken'
     assert mention == ''
+
 
 def test_destination_parsing_defaults_for_incident():
     hipchat_vendor = iris_hipchat({


### PR DESCRIPTION
Originally the hipchat vendor only supported sending notifications to a single room with a "mention" of the user who it's meant for.

This PR allows another scenarios: if the destination value has the correct syntax, we send to the specified room_id. If a username was mentioned (@ prefix) we also do the mention.

Also fixes missing hipchat metrics.