### PR TITLE
Indicate in UI why we failed to expand too large ldap lists

### DIFF
--- a/src/iris/role_lookup/__init__.py
+++ b/src/iris/role_lookup/__init__.py
@@ -6,6 +6,10 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+class IrisRoleLookupException(Exception):
+    pass
+
+
 def get_role_lookups(config):
     modules = config.get('role_lookups', [])
 

--- a/src/iris/role_lookup/mailing_list.py
+++ b/src/iris/role_lookup/mailing_list.py
@@ -2,6 +2,7 @@
 # See LICENSE in the project root for license information.
 
 from iris import db
+from iris.role_lookup import IrisRoleLookupException
 import logging
 logger = logging.getLogger(__name__)
 
@@ -43,7 +44,7 @@ class mailing_list(object):
                         list_name, list_count, self.max_list_names)
             cursor.close()
             connection.close()
-            return None
+            raise IrisRoleLookupException('List %s contains too many members to safely expand (%s >= %s)' % (list_name, list_count, self.max_list_names))
 
         cursor.execute('''SELECT `target`.`name`
                           FROM `mailing_list_membership`

--- a/src/iris/sender/rpc.py
+++ b/src/iris/sender/rpc.py
@@ -10,6 +10,7 @@ import msgpack
 from ..utils import msgpack_unpack_msg_from_socket, sanitize_unicode_dict
 from . import cache
 from iris import metrics
+from iris.role_lookup import IrisRoleLookupException
 
 import logging
 logger = logging.getLogger(__name__)
@@ -89,7 +90,10 @@ def handle_api_notification_request(socket, address, req):
                     target, notification['application'])
         return
 
-    expanded_targets = cache.targets_for_role(role, target)
+    try:
+        expanded_targets = cache.targets_for_role(role, target)
+    except IrisRoleLookupException:
+        expanded_targets = None
     if not expanded_targets:
         reject_api_request(socket, address, 'INVALID role:target')
         logger.warn('Dropping OOB message with invalid role:target "%s:%s" from app %s',


### PR DESCRIPTION
- Introduce a custom exception for passing deliberate failures from role lookup
  modules to sender, and use that for passing across the cause