### PR TITLE
Fix retention script: get messages that have null mode

### DIFF
--- a/src/iris/bin/retention.py
+++ b/src/iris/bin/retention.py
@@ -173,7 +173,7 @@ def process_retention(engine, max_days, batch_size, cooldown_time, archive_path)
                           %s
                         FROM `message`
                         JOIN `priority` on `priority`.`id` = `message`.`priority_id`
-                        JOIN `mode` on `mode`.`id` = `message`.`mode_id`
+                        LEFT JOIN `mode` on `mode`.`id` = `message`.`mode_id`
                         LEFT JOIN `template` ON `message`.`template_id` = `template`.`id`
                         LEFT JOIN `target` ON `message`.`target_id` = `target`.`id`
                         WHERE `message`.`incident_id` in %%s


### PR DESCRIPTION
Retention script currently chokes when trying to delete an incident has
messages of mode NULL. Fix that by making the join on mode LEFT.

(When I wrote this I forgot that `mode` can be set to null initially)