### PR TITLE
Allow iris api url to be configured in config file instead of default http://127.0.0.1:16649

### DIFF
--- a/configs/config.dev.yaml
+++ b/configs/config.dev.yaml
@@ -5,6 +5,7 @@ server:
   host: 0.0.0.0
   port: 16649
   disable_auth: True # allow logins by existing users, but without checking credentials
+  local_api_url: http://localhost:16649
 
 db: &db
   conn:


### PR DESCRIPTION
When using iris api behind an https reverse proxy (nginx for example) the `get_local` function try to fetch information from `http://127.0.0.1:16649` instead of `https://{{ host }}:16649`.
This pull request allow iris api-url configuration directly from config file.
I've also renamed the `get_local` method to `get_iris_api`.