### PR TITLE
Support name query-param in /targets/{target_type}

### DIFF
--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -2256,6 +2256,9 @@ class Target(object):
             req.params['startswith'] = req.params['startswith'] + '%'
             filters_sql.append('`name` like :startswith')
 
+        if 'name' in req.params:
+            filters_sql.append('`name` = :name')
+
         active = req.get_param_as_bool('active')
         if active is not None:
             req.params['active'] = active

--- a/test/e2etest.py
+++ b/test/e2etest.py
@@ -1842,6 +1842,18 @@ def test_get_targets(sample_user, sample_user2, sample_team, sample_team2):
     assert sample_user in data
     assert sample_user2 not in data
 
+    re = requests.get(base_url + 'targets/user?name=' + sample_user)
+    data = re.json()
+    assert re.status_code == 200
+    assert sample_user in data
+    assert sample_user2 not in data
+
+    re = requests.get(base_url + 'targets/team?name=' + sample_team)
+    data = re.json()
+    assert re.status_code == 200
+    assert sample_team in data
+    assert sample_team2 not in data
+
 
 @pytest.mark.skip(reason="reanble this test when we can programatically create noc user in the test")
 def test_post_plan_noc(sample_user, sample_team, sample_application_name):


### PR DESCRIPTION
This API currently supports startswith, this commit supports
name as query-param. Tests added.

Usage:
/v0/targets/team?name=foo_team
/v0/targets/mailing-list?name=abc