### PR TITLE
Turn off autoescape for plan tracking templates

### DIFF
--- a/src/iris/sender/cache.py
+++ b/src/iris/sender/cache.py
@@ -191,7 +191,9 @@ class Plans():
         self.engine = engine
         self.active = {}
         self.data = {}
-        self.template_env = SandboxedEnvironment(autoescape=True)
+        # Autoescape turned off since HTML characters can exist in plan tracking template.
+        # See details in Templates()
+        self.template_env = SandboxedEnvironment(autoescape=False)
 
     def __getitem__(self, key):
         try:


### PR DESCRIPTION
Unneeded, double-encodes HTML characters.