### PR TITLE
Updated iris slack vendor to be compatible with mattermost

### DIFF
--- a/test/test_iris_vendor_slack.py
+++ b/test/test_iris_vendor_slack.py
@@ -2,7 +2,6 @@
 # -*- coding:utf-8 -*-
 
 from iris.vendors.iris_slack import iris_slack
-import ujson as json
 
 
 def test_atttachments_construction_for_incident():
@@ -27,7 +26,7 @@ def test_atttachments_construction_for_incident():
     assert msg_payload['channel'] == '@user1'
 
     attachments = msg_payload['attachments']
-    assert json.loads(attachments) == [{
+    assert attachments == [{
         'fallback': 'foo fallback',
         'pretext': 'foo pretext',
         'title': 'Iris incident %r' % fake_msg['incident_id'],


### PR DESCRIPTION
This PR update de iris slack vendor plugin to be compatible with mattermost :
 - all the payload is json dumped not only the attachement
 - the returned value is checked in text or in json

Tested with slack and mattermost (the claim button don't work in mattermost but that's okay for now).