### PR TITLE
influx metric field keys need to make sense

### DIFF
--- a/src/iris/metrics/influx.py
+++ b/src/iris/metrics/influx.py
@@ -39,7 +39,7 @@ class influx(object):
                 'tags': {},
                 'time': now,
                 'fields': {
-                    metric : value
+                    metric: value
                 }
             }
             if self.extra_tags:

--- a/src/iris/metrics/influx.py
+++ b/src/iris/metrics/influx.py
@@ -35,11 +35,11 @@ class influx(object):
         payload = []
         for metric, value in metrics.iteritems():
             data = {
-                'measurement': self.appname + '_' + metric,
+                'measurement': self.appname,
                 'tags': {},
                 'time': now,
                 'fields': {
-                    'value': value
+                    metric : value
                 }
             }
             if self.extra_tags:


### PR DESCRIPTION
rather than a flat measurement schema, the module name is the measurement name, and the field key name is the metric name, with the value being the value. This allows for cleaner influx queries, eg:

    > select "email_avg" from "iris-sender" limit 5
    name: iris-sender
    time                email_avg
    ----                ---------
    1530819817229080064 0
    1530819876027269120 0
    1530819936026919936 0
    1530819996027867904 0
    1530820056025811968 0
    >