### PR TITLE
cast all influx metric values to floats

### DIFF
--- a/src/iris/metrics/influx.py
+++ b/src/iris/metrics/influx.py
@@ -39,7 +39,7 @@ class influx(object):
                 'tags': {},
                 'time': now,
                 'fields': {
-                    metric: value
+                    metric: float(value)
                 }
             }
             if self.extra_tags:


### PR DESCRIPTION
this resolves a bug where initial metric creation of 0 values meant that some metrics got an `integer` type in Influx. Then when those values change per internal statistics calculations, they can't be inserted into Influx as floats because they were originally defined as integers:

    2018-07-05 21:24:36,027 INFO root --> sender loop finished in 0.0274050235748 seconds - sleeping 59.9725949764 seconds
    2018-07-05 21:24:36,080 ERROR root Failed to send metrics to influxdb
    Traceback (most recent call last):
      File "/home/iris/env/local/lib/python2.7/site-packages/iris/metrics/influx.py", line 50, in send_metrics
    self.client.write_points(payload)
      File "/home/iris/env/local/lib/python2.7/site-packages/influxdb/client.py", line 402, in write_points
    tags=tags)
      File "/home/iris/env/local/lib/python2.7/site-packages/influxdb/client.py", line 447, in _write_points
    expected_response_code=204
      File "/home/iris/env/local/lib/python2.7/site-packages/influxdb/client.py", line 289, in write
    headers=headers
      File "/home/iris/env/local/lib/python2.7/site-packages/influxdb/client.py", line 259, in request
        raise InfluxDBClientError(response.content, response.status_code)
    InfluxDBClientError: 400: {"error":"partial write: field type conflict: input field \"email_max\" on measurement \"iris-sender\" is type float, already exists as type integer dropped=2"}
