### PR TITLE
Change how inactive messages are cleaned, change log levels

### DIFF
--- a/src/iris/bin/sender.py
+++ b/src/iris/bin/sender.py
@@ -380,7 +380,7 @@ def deactivate():
     max_retries = 3
 
     # this deadlocks sometimes. try until it doesn't.
-    for i in xrange(max_retries):
+    for i in xrange(1, max_retries + 1):
         try:
             cursor.execute(GET_INACTIVE_IDS_SQL)
             ids = tuple(r[0] for r in cursor)
@@ -389,10 +389,10 @@ def deactivate():
                 connection.commit()
                 break
         except Exception:
-            if i == max_retries - 1:
-                logger.exception('Failed running deactivate query. (Try %s/%s)', i + 1, max_retries)
+            if i == max_retries:
+                logger.exception('Failed running deactivate query. (Try %s/%s)', i, max_retries)
             else:
-                logger.warn('Deadlocked running deactivate query. (Try %s/%s)', i + 1, max_retries)
+                logger.warn('Deadlocked running deactivate query. (Try %s/%s)', i, max_retries)
             sleep(.2)
 
     cursor.close()
@@ -553,7 +553,7 @@ def aggregate(now):
                 logger.info('[-] purged %s from messages %s remaining', active_message_ids, len(messages))
             del queues[key]
             sent[key] = now
-    inactive_message_ids = set(messages.keys()) - all_actives
+    inactive_message_ids = messages.viewkeys() - all_actives
     logger.info('[x] dropped %s inactive messages from claimed incidents, %s remain',
                 len(inactive_message_ids), len(messages))
 
@@ -909,7 +909,7 @@ def mark_message_as_sent(message):
     max_retries = 3
 
     # this deadlocks sometimes. try until it doesn't.
-    for i in xrange(max_retries):
+    for i in xrange(1, max_retries + 1):
         try:
             cursor.execute(sql, params)
             connection.commit()
@@ -918,10 +918,10 @@ def mark_message_as_sent(message):
             logger.exception('Failed updating message metadata status (message ID %s) (application %s)', message.get('message_id', '?'), message.get('application', '?'))
             break
         except Exception:
-            if i == max_retries - 1:
-                logger.exception('Failed running sent message update query. (Try %s/%s)', i + 1, max_retries)
+            if i == max_retries:
+                logger.exception('Failed running sent message update query. (Try %s/%s)', i, max_retries)
             else:
-                logger.warn('Failed running sent message update query. (Try %s/%s)', i + 1, max_retries)
+                logger.warn('Failed running sent message update query. (Try %s/%s)', i, max_retries)
             sleep(.2)
 
     # Clean messages cache
@@ -945,7 +945,7 @@ def mark_message_as_sent(message):
     max_retries = 3
 
     # this deadlocks sometimes. try until it doesn't.
-    for i in xrange(max_retries):
+    for i in xrange(1, max_retries + 1):
         try:
             cursor.execute(UPDATE_MESSAGE_BODY_SQL, (message['body'], message['subject'], update_ids))
             connection.commit()
@@ -954,10 +954,10 @@ def mark_message_as_sent(message):
             logger.exception('Failed updating message body+subject (message IDs %s) (application %s)', update_ids, message.get('application', '?'))
             break
         except Exception:
-            if i == max_retries - 1:
-                logger.exception('Failed updating message body+subject (message IDs %s) (application %s) (Try %s/%s)', update_ids, message.get('application', '?'), i + 1, max_retries)
+            if i == max_retries:
+                logger.exception('Failed updating message body+subject (message IDs %s) (application %s) (Try %s/%s)', update_ids, message.get('application', '?'), i, max_retries)
             else:
-                logger.warn('Failed updating message body+subject (message IDs %s) (application %s) (Try %s/%s)', update_ids, message.get('application', '?'), i + 1, max_retries)
+                logger.warn('Failed updating message body+subject (message IDs %s) (application %s) (Try %s/%s)', update_ids, message.get('application', '?'), i, max_retries)
             sleep(.2)
 
     cursor.close()


### PR DESCRIPTION
Get all actives before aggregate task, clear all inactives at the
end. Saves a few DB queries, avoids leaks.
Also, demote non-fatal DB errors to warnings