### PR TITLE
Enable fault tolerance for exchangelib

### DIFF
--- a/src/iris/bin/owasync.py
+++ b/src/iris/bin/owasync.py
@@ -194,7 +194,7 @@ def main():
         UseProxyHttpAdapter._my_proxies = proxies
         exchangelib.protocol.BaseProtocol.HTTP_ADAPTER_CLS = UseProxyHttpAdapter
 
-    creds = exchangelib.Credentials(**owaconfig['credentials'])
+    creds = exchangelib.ServiceAccount(**owaconfig['credentials'])
 
     try:
         nap_time = int(owaconfig.get('sleep_interval', 60))


### PR DESCRIPTION
Use ServiceAccount instead of Credentials for long-running job,
as recommended in docs