### PR TITLE
Precompute global iris stats

### DIFF
--- a/db/schema_0.sql
+++ b/db/schema_0.sql
@@ -751,18 +751,10 @@ CREATE TABLE `application_stats` (
 
 DROP TABLE IF EXISTS `global_stats`;
 CREATE TABLE `global_stats` (
-  `id` BIGINT(20) NOT NULL AUTO_INCREMENT,
-  `median_seconds_to_claim_last_month` FLOAT,
-  `total_incidents_today` BIGINT(20),
-  `total_active_users` BIGINT(20),
-  `total_plans` BIGINT(20),
-  `total_messages_sent` BIGINT(20),
-  `total_applications` BIGINT(20),
-  `pct_incidents_claimed_last_month` FLOAT,
-  `total_incidents` BIGINT(20),
-  `total_messages_sent_today` BIGINT(20),
+  `statistic` VARCHAR(255) NOT NULL,
+  `value` FLOAT NOT NULL,
   `timestamp` DATETIME NOT NULL,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`statistic`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
 

--- a/db/schema_0.sql
+++ b/db/schema_0.sql
@@ -749,6 +749,22 @@ CREATE TABLE `application_stats` (
     ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
+DROP TABLE IF EXISTS `global_stats`;
+CREATE TABLE `global_stats` (
+  `id` BIGINT(20) NOT NULL AUTO_INCREMENT,
+  `median_seconds_to_claim_last_month` FLOAT,
+  `total_incidents_today` BIGINT(20),
+  `total_active_users` BIGINT(20),
+  `total_plans` BIGINT(20),
+  `total_messages_sent` BIGINT(20),
+  `total_applications` BIGINT(20),
+  `pct_incidents_claimed_last_month` FLOAT,
+  `total_incidents` BIGINT(20),
+  `total_messages_sent_today` BIGINT(20),
+  `timestamp` DATETIME NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
 
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;

--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -15,7 +15,6 @@ import os
 import datetime
 import logging
 import jinja2
-import itertools
 from jinja2.sandbox import SandboxedEnvironment
 from urlparse import parse_qs
 import ujson
@@ -4015,33 +4014,15 @@ class Stats(object):
         connection = db.engine.raw_connection()
         cursor = connection.cursor()
         if self.real_time:
-            stats = app_stats.calculate_gobal_stats(connection, cursor, fields_filter=fields_filter)
+            stats = app_stats.calculate_global_stats(connection, cursor, fields_filter=fields_filter)
 
         else:
-            # select the most current global stats entry
-            query = '''
-                SELECT `median_seconds_to_claim_last_month`, `total_incidents_today`, `total_active_users`, `total_plans`, `total_messages_sent`,
-                `total_applications`, `pct_incidents_claimed_last_month`, `total_incidents`, `total_messages_sent_today`, `timestamp`
-                FROM `global_stats` gs1
-                WHERE `timestamp` = (SELECT MAX(`timestamp`) from `global_stats` gs2 WHERE gs2.`timestamp` = gs1.`timestamp`)
-            '''
-            cursor.execute(query)
-
-            if cursor.rowcount == 0:
-                logger.error('Error retrieving global stats from db')
-                raise HTTPInternalServerError('Error retrieving global stats from db')
-
-            # build dictionary of stat names and values
-            desc = cursor.description
-            column_names = [col[0] for col in desc]
-            stats = [dict(itertools.izip(column_names, row))
-                     for row in cursor.fetchall()]
-            stats = stats[0]
-
+            cursor.execute('SELECT `statistic`, `value` FROM `global_stats`')
+            stats = {row[0]: row[1] for row in cursor}
         cursor.close()
         connection.close()
         resp.status = HTTP_200
-        resp.body = ujson.dumps(stats)
+        resp.body = ujson.dumps(stats, sort_keys=True)
 
 
 class ApplicationStats(object):

--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -4018,7 +4018,11 @@ class Stats(object):
 
         else:
             cursor.execute('SELECT `statistic`, `value` FROM `global_stats`')
+            if cursor.rowcount == 0:
+                logger.exception('Error retrieving global stats from db')
+                raise HTTPInternalServerError('Error retrieving global stats from db')
             stats = {row[0]: row[1] for row in cursor}
+
         cursor.close()
         connection.close()
         resp.status = HTTP_200
@@ -4050,6 +4054,10 @@ class ApplicationStats(object):
         else:
             cursor.execute('''SELECT `statistic`, `value` FROM `application_stats` WHERE `application_id` = %s''',
                            app['id'])
+            if cursor.rowcount == 0:
+                logger.exception('Error retrieving app stats from db')
+                raise HTTPInternalServerError('Error retrieving app stats from db')
+
             stats = {row[0]: row[1] for row in cursor}
         cursor.close()
         connection.close()

--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -15,6 +15,7 @@ import os
 import datetime
 import logging
 import jinja2
+import itertools
 from jinja2.sandbox import SandboxedEnvironment
 from urlparse import parse_qs
 import ujson
@@ -616,7 +617,7 @@ def is_valid_tracking_settings(t, k, tpl):
             try:
                 environment.from_string(tpl[app]['body'])
             except jinja2.TemplateSyntaxError as e:
-                    return False, 'Invalid jinja syntax in incident tracking text: %s' % e
+                return False, 'Invalid jinja syntax in incident tracking text: %s' % e
     return True, None
 
 
@@ -1469,7 +1470,7 @@ class Incidents(object):
 
             context = incident_params['context']
             context_json_str = ujson.dumps({variable: context.get(variable)
-                                           for variable in app['variables']})
+                                            for variable in app['variables']})
             if len(context_json_str) > 65535:
                 raise HTTPBadRequest('Context too long')
 
@@ -1946,39 +1947,39 @@ class Template(object):
     allow_read_no_auth = True
 
     def on_get(self, req, resp, template_id):
-            if template_id.isdigit():
-                where = 'WHERE `template`.`id` = %s'
-            else:
-                where = 'WHERE `template`.`name` = %s AND `template_active`.`template_id` IS NOT NULL'
-            query = single_template_query + where
+        if template_id.isdigit():
+            where = 'WHERE `template`.`id` = %s'
+        else:
+            where = 'WHERE `template`.`name` = %s AND `template_active`.`template_id` IS NOT NULL'
+        query = single_template_query + where
 
-            connection = db.engine.raw_connection()
-            cursor = connection.cursor()
-            cursor.execute(query, template_id)
-            results = cursor.fetchall()
+        connection = db.engine.raw_connection()
+        cursor = connection.cursor()
+        cursor.execute(query, template_id)
+        results = cursor.fetchall()
 
-            if results:
-                r = results[0]
-                t = {
-                    'id': r[0],
-                    'name': r[1],
-                    'active': r[2],
-                    'creator': r[3],
-                    'created': r[4]
-                }
-                content = {}
-                for r in results:
-                    content.setdefault(r[5], {})[r[6]] = {'subject': r[7], 'body': r[8]}
-                t['content'] = content
-                cursor = connection.cursor(db.dict_cursor)
-                cursor.execute(single_template_query_plans, t['name'])
-                t['plans'] = cursor.fetchall()
-                connection.close()
-                payload = ujson.dumps(t)
-            else:
-                raise HTTPNotFound()
-            resp.status = HTTP_200
-            resp.body = payload
+        if results:
+            r = results[0]
+            t = {
+                'id': r[0],
+                'name': r[1],
+                'active': r[2],
+                'creator': r[3],
+                'created': r[4]
+            }
+            content = {}
+            for r in results:
+                content.setdefault(r[5], {})[r[6]] = {'subject': r[7], 'body': r[8]}
+            t['content'] = content
+            cursor = connection.cursor(db.dict_cursor)
+            cursor.execute(single_template_query_plans, t['name'])
+            t['plans'] = cursor.fetchall()
+            connection.close()
+            payload = ujson.dumps(t)
+        else:
+            raise HTTPNotFound()
+        resp.status = HTTP_200
+        resp.body = payload
 
     def on_post(self, req, resp, template_id):
         template_params = ujson.loads(req.context['body'])
@@ -4002,67 +4003,43 @@ class Healthcheck(object):
 class Stats(object):
     allow_read_no_auth = True
 
-    def on_get(self, req, resp):
-        queries = {
-            'total_plans': 'SELECT COUNT(*) FROM `plan`',
-            'total_incidents': 'SELECT COUNT(*) FROM `incident`',
-            'total_messages_sent': 'SELECT COUNT(*) FROM `message`',
-            'total_incidents_today': 'SELECT COUNT(*) FROM `incident` WHERE `created` >= CURDATE()',
-            'total_messages_sent_today': 'SELECT COUNT(*) FROM `message` WHERE `sent` >= CURDATE()',
-            'total_active_users': 'SELECT COUNT(*) FROM `target` WHERE `type_id` = (SELECT `id` FROM `target_type` WHERE `name` = "user") AND `active` = TRUE',
-            'pct_incidents_claimed_last_month': '''SELECT ROUND(
-                                                   (SELECT COUNT(*) FROM `incident`
-                                                    WHERE `created` > (CURRENT_DATE - INTERVAL 29 DAY)
-                                                    AND `created` < (CURRENT_DATE - INTERVAL 1 DAY)
-                                                    AND `active` = FALSE
-                                                    AND NOT isnull(`owner_id`)) /
-                                                   (SELECT COUNT(*) FROM `incident`
-                                                    WHERE `created` > (CURRENT_DATE - INTERVAL 29 DAY)
-                                                    AND `created` < (CURRENT_DATE - INTERVAL 1 DAY)) * 100, 2)''',
-            'median_seconds_to_claim_last_month': '''SELECT @incident_count := (SELECT count(*)
-                                                                                FROM `incident`
-                                                                                WHERE `created` > (CURRENT_DATE - INTERVAL 29 DAY)
-                                                                                AND `created` < (CURRENT_DATE - INTERVAL 1 DAY)
-                                                                                AND `active` = FALSE
-                                                                                AND NOT ISNULL(`owner_id`)
-                                                                                AND NOT ISNULL(`updated`)),
-                                                            @row_id := 0,
-                                                            (SELECT CEIL(AVG(time_to_claim)) as median
-                                                            FROM (SELECT `updated` - `created` as time_to_claim
-                                                                  FROM `incident`
-                                                                  WHERE `created` > (CURRENT_DATE - INTERVAL 29 DAY)
-                                                                  AND `created` < (CURRENT_DATE - INTERVAL 1 DAY)
-                                                                  AND `active` = FALSE
-                                                                  AND NOT ISNULL(`owner_id`)
-                                                                  AND NOT ISNULL(`updated`)
-                                                                  ORDER BY time_to_claim) as time_to_claim
-                                                            WHERE (SELECT @row_id := @row_id + 1)
-                                                            BETWEEN @incident_count/2.0 AND @incident_count/2.0 + 1)''',
-            'total_applications': 'SELECT COUNT(*) FROM `application` WHERE `auth_only` = FALSE'
-        }
+    def __init__(self, config):
+        cfg = config.get('app-stats', {})
+        # Calculate stats in real time (True), or query offline stats
+        # generated by the app stats daemon (False)
+        self.real_time = cfg.get('real_time', True)
 
-        stats = {}
+    def on_get(self, req, resp):
 
         fields_filter = req.get_param_as_list('fields')
-        fields = queries.viewkeys()
-        if fields_filter:
-            fields &= set(fields_filter)
-
         connection = db.engine.raw_connection()
         cursor = connection.cursor()
-        for key in fields:
-            start = time.time()
-            cursor.execute(queries[key])
-            result = cursor.fetchone()
-            if result:
-                result = result[-1]
-            else:
-                result = None
-            logger.info('Stats query %s took %s seconds', key, round(time.time() - start, 2))
-            stats[key] = result
+        if self.real_time:
+            stats = app_stats.calculate_gobal_stats(connection, cursor, fields_filter=fields_filter)
+
+        else:
+            # select the most current global stats entry
+            query = '''
+                SELECT `median_seconds_to_claim_last_month`, `total_incidents_today`, `total_active_users`, `total_plans`, `total_messages_sent`,
+                `total_applications`, `pct_incidents_claimed_last_month`, `total_incidents`, `total_messages_sent_today`, `timestamp`
+                FROM `global_stats` gs1
+                WHERE `timestamp` = (SELECT MAX(`timestamp`) from `global_stats` gs2 WHERE gs2.`timestamp` = gs1.`timestamp`)
+            '''
+            cursor.execute(query)
+
+            if cursor.rowcount == 0:
+                logger.error('Error retrieving global stats from db')
+                raise HTTPInternalServerError('Error retrieving global stats from db')
+
+            # build dictionary of stat names and values
+            desc = cursor.description
+            column_names = [col[0] for col in desc]
+            stats = [dict(itertools.izip(column_names, row))
+                     for row in cursor.fetchall()]
+            stats = stats[0]
+
         cursor.close()
         connection.close()
-
         resp.status = HTTP_200
         resp.body = ujson.dumps(stats)
 
@@ -4224,7 +4201,7 @@ def construct_falcon_api(debug, healthcheck_path, allowed_origins, iris_sender_a
     if mobile_config.get('activated'):
         api.add_route('/v0/devices', Devices(mobile_config))
 
-    api.add_route('/v0/stats', Stats())
+    api.add_route('/v0/stats', Stats(config))
 
     api.add_route('/v0/timezones', SupportedTimezones(supported_timezones))
 

--- a/src/iris/app_stats.py
+++ b/src/iris/app_stats.py
@@ -135,7 +135,7 @@ def calculate_app_stats(app, connection, cursor, fields_filter=None):
     return stats
 
 
-def calculate_gobal_stats(connection, cursor, fields_filter=None):
+def calculate_global_stats(connection, cursor, fields_filter=None):
 
     queries = {
         'total_plans': 'SELECT COUNT(*) FROM `plan`',

--- a/src/iris/app_stats.py
+++ b/src/iris/app_stats.py
@@ -133,3 +133,62 @@ def calculate_app_stats(app, connection, cursor, fields_filter=None):
         if count_stat not in stats:
             stats[count_stat] = 0
     return stats
+
+
+def calculate_gobal_stats(connection, cursor, fields_filter=None):
+
+    queries = {
+        'total_plans': 'SELECT COUNT(*) FROM `plan`',
+        'total_incidents': 'SELECT COUNT(*) FROM `incident`',
+        'total_messages_sent': 'SELECT COUNT(*) FROM `message`',
+        'total_incidents_today': 'SELECT COUNT(*) FROM `incident` WHERE `created` >= CURDATE()',
+        'total_messages_sent_today': 'SELECT COUNT(*) FROM `message` WHERE `sent` >= CURDATE()',
+        'total_active_users': 'SELECT COUNT(*) FROM `target` WHERE `type_id` = (SELECT `id` FROM `target_type` WHERE `name` = "user") AND `active` = TRUE',
+        'pct_incidents_claimed_last_month': '''SELECT ROUND(
+                                                (SELECT COUNT(*) FROM `incident`
+                                                WHERE `created` > (CURRENT_DATE - INTERVAL 29 DAY)
+                                                AND `created` < (CURRENT_DATE - INTERVAL 1 DAY)
+                                                AND `active` = FALSE
+                                                AND NOT isnull(`owner_id`)) /
+                                                (SELECT COUNT(*) FROM `incident`
+                                                WHERE `created` > (CURRENT_DATE - INTERVAL 29 DAY)
+                                                AND `created` < (CURRENT_DATE - INTERVAL 1 DAY)) * 100, 2)''',
+        'median_seconds_to_claim_last_month': '''SELECT @incident_count := (SELECT count(*)
+                                                                            FROM `incident`
+                                                                            WHERE `created` > (CURRENT_DATE - INTERVAL 29 DAY)
+                                                                            AND `created` < (CURRENT_DATE - INTERVAL 1 DAY)
+                                                                            AND `active` = FALSE
+                                                                            AND NOT ISNULL(`owner_id`)
+                                                                            AND NOT ISNULL(`updated`)),
+                                                        @row_id := 0,
+                                                        (SELECT CEIL(AVG(time_to_claim)) as median
+                                                        FROM (SELECT `updated` - `created` as time_to_claim
+                                                                FROM `incident`
+                                                                WHERE `created` > (CURRENT_DATE - INTERVAL 29 DAY)
+                                                                AND `created` < (CURRENT_DATE - INTERVAL 1 DAY)
+                                                                AND `active` = FALSE
+                                                                AND NOT ISNULL(`owner_id`)
+                                                                AND NOT ISNULL(`updated`)
+                                                                ORDER BY time_to_claim) as time_to_claim
+                                                        WHERE (SELECT @row_id := @row_id + 1)
+                                                        BETWEEN @incident_count/2.0 AND @incident_count/2.0 + 1)''',
+        'total_applications': 'SELECT COUNT(*) FROM `application` WHERE `auth_only` = FALSE'
+    }
+
+    stats = {}
+    fields = queries.viewkeys()
+    if fields_filter:
+        fields &= set(fields_filter)
+
+    for key in fields:
+        start = time.time()
+        cursor.execute(queries[key])
+        result = cursor.fetchone()
+        if result:
+            result = result[-1]
+        else:
+            result = None
+        logger.info('Stats query %s took %s seconds', key, round(time.time() - start, 2))
+        stats[key] = result
+
+    return stats

--- a/src/iris/bin/app_stats.py
+++ b/src/iris/bin/app_stats.py
@@ -40,6 +40,30 @@ stats_reset = {
 }
 
 
+def set_global_stats(stats, connection, cursor):
+
+    query_args = []
+    query_args.append(stats['median_seconds_to_claim_last_month'])
+    query_args.append(stats['total_incidents_today'])
+    query_args.append(stats['total_active_users'])
+    query_args.append(stats['total_plans'])
+    query_args.append(stats['total_messages_sent'])
+    query_args.append(stats['total_applications'])
+    query_args.append(stats['pct_incidents_claimed_last_month'])
+    query_args.append(stats['total_incidents'])
+    query_args.append(stats['total_messages_sent_today'])
+
+    query = '''
+        INSERT INTO `global_stats`
+        (`median_seconds_to_claim_last_month`, `total_incidents_today`, `total_active_users`, `total_plans`, `total_messages_sent`,
+        `total_applications`, `pct_incidents_claimed_last_month`, `total_incidents`, `total_messages_sent_today`, `timestamp`)
+        VALUES(%s, %s, %s, %s, %s, %s, %s, %s, %s, NOW())
+    '''
+
+    cursor.execute(query, query_args)
+    connection.commit()
+
+
 def set_app_stats(app, stats, connection, cursor):
     for stat, val in stats.iteritems():
         if val is not None:
@@ -62,6 +86,13 @@ def stats_task():
         except Exception:
             logger.exception('App stats calculation failed for app %s', app['name'])
             metrics.incr('task_failure')
+    try:
+        stats = app_stats.calculate_gobal_stats(connection, cursor)
+        set_global_stats(stats, connection, cursor)
+    except Exception:
+        logger.exception('Global stats calculation failed')
+        metrics.incr('task_failure')
+
     cursor.close()
     connection.close()
 


### PR DESCRIPTION
Add the option to precompute global iris stats and retrieve them from the db instead of calculating them for every request.