### PR TITLE
Put ACLs on claimer/creator for incidents, plans, and templates

### DIFF
--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -899,9 +899,9 @@ def acl_allowed(req, username):
     Allow if the username matches the session user, if an app is using an API key and is
     allowed to authenticate users, or if the user is an admin.
     '''
-    return req.context['username'] == username or \
-        req.context.get('app', {}).get('allow_authenticating_users') or \
-        req.context['is_admin']
+    return (req.context['username'] == username or
+            req.context.get('app', {}).get('allow_authenticating_users') or
+            req.context['is_admin'])
 
 
 class Plan(object):
@@ -2120,7 +2120,7 @@ class Templates(object):
                         logger.exception('Invalid jinja syntax')
                         raise HTTPBadRequest('Invalid jinja template', str(e))
                     contents.append(_content)
-        except HTTPBadRequest, HTTPUnauthorized:
+        except (HTTPBadRequest, HTTPUnauthorized):
             raise
         except Exception:
             logger.exception('SERVER ERROR')

--- a/src/iris/ui/__init__.py
+++ b/src/iris/ui/__init__.py
@@ -290,7 +290,8 @@ class Login():
             flash_message(req, 'Invalid credentials', 'danger')
             raise HTTPFound('/login')
 
-        url = req.get_param('next')
+        # Remove newlines to prevent HTTP request splitting
+        url = req.get_param('next', default='').replace('\n', '')
 
         if not url or url.startswith('/'):
             raise HTTPFound(url or default_route)
@@ -432,7 +433,8 @@ def init(config, app):
         'session.validate_key': config['user_session']['sign_key'],
         'session.secure': not (config['server'].get('disable_auth', False) or config['server'].get('allow_http', False)),
         'session.httponly': True,
-        'session.crypto_type': 'cryptography'
+        'session.crypto_type': 'cryptography',
+        'session.samesite': 'Lax'
     }
     app = SessionMiddleware(app, session_opts)
 

--- a/test/e2etest.py
+++ b/test/e2etest.py
@@ -905,7 +905,7 @@ def test_post_plan(sample_user, sample_team, sample_template_name):
     data['steps'] = sorted(data['steps'], key=lambda x: x[0]['priority'] + x[1]['priority'])
 
     # Test post to plans endpoint (create plan)
-    re = requests.post(base_url + 'plans', json=data)
+    re = requests.post(base_url + 'plans', json=data, headers=username_header(sample_user))
     assert re.status_code == 201
     plan_id = re.content.strip()
     new_data = requests.get(base_url + 'plans/' + str(plan_id)).json()
@@ -967,7 +967,7 @@ def test_post_plan(sample_user, sample_team, sample_template_name):
                 "template": sample_template_name}
     # Test bad role
     data['steps'][0][0] = bad_step
-    re = requests.post(base_url + 'plans', json=data)
+    re = requests.post(base_url + 'plans', json=data, headers=username_header(sample_user))
     assert re.status_code == 400
     assert re.json()['description'] == 'Role not found for step 1'
 
@@ -975,7 +975,7 @@ def test_post_plan(sample_user, sample_team, sample_template_name):
     bad_step['role'] = 'user'
     bad_step['target'] = invalid_user
     data['steps'][0][0] = bad_step
-    re = requests.post(base_url + 'plans', json=data)
+    re = requests.post(base_url + 'plans', json=data, headers=username_header(sample_user))
     assert re.status_code == 400
     assert re.json()['description'] == 'Target %s not found for step 1' % invalid_user
 
@@ -983,7 +983,7 @@ def test_post_plan(sample_user, sample_team, sample_template_name):
     bad_step['target'] = sample_team
     bad_step['priority'] = 'foo'
     data['steps'][0][0] = bad_step
-    re = requests.post(base_url + 'plans', json=data)
+    re = requests.post(base_url + 'plans', json=data, headers=username_header(sample_user))
     assert re.status_code == 400
     assert re.json()['description'] == 'Priority not found for step 1'
 
@@ -1039,7 +1039,7 @@ def test_post_dynamic_plan(sample_user, sample_team, sample_template_name):
     data['steps'] = sorted(data['steps'], key=lambda x: x[0]['priority'] + x[1]['priority'])
 
     # Test post to plans endpoint (create plan)
-    re = requests.post(base_url + 'plans', json=data)
+    re = requests.post(base_url + 'plans', json=data, headers=username_header(sample_user))
     assert re.status_code == 201
     plan_id = re.content.strip()
     new_data = requests.get(base_url + 'plans/' + str(plan_id)).json()
@@ -1064,7 +1064,7 @@ def test_post_dynamic_plan(sample_user, sample_team, sample_template_name):
                 "template": sample_template_name}
     # Test bad dynamic target index
     data['steps'][0][0] = bad_step
-    re = requests.post(base_url + 'plans', json=data)
+    re = requests.post(base_url + 'plans', json=data, headers=username_header(sample_user))
     assert re.status_code == 400
     assert re.json()['description'] == 'Dynamic target numbers must span 0..n without gaps'
 
@@ -1106,7 +1106,7 @@ def test_delete_plan(sample_user, sample_team, sample_template_name, sample_appl
     }
 
     # Test creating and deleting by ID
-    re = requests.post(base_url + 'plans', json=data)
+    re = requests.post(base_url + 'plans', json=data, headers=username_header(sample_user))
     assert re.status_code == 201
     plan_id = re.content.strip()
     assert plan_id
@@ -1121,7 +1121,7 @@ def test_delete_plan(sample_user, sample_team, sample_template_name, sample_appl
     assert re.status_code == 404
 
     # Test creating and deleting by name
-    re = requests.post(base_url + 'plans', json=data)
+    re = requests.post(base_url + 'plans', json=data, headers=username_header(sample_user))
     assert re.status_code == 201
     plan_id = re.content.strip()
     assert plan_id
@@ -1139,7 +1139,7 @@ def test_delete_plan(sample_user, sample_team, sample_template_name, sample_appl
     data_cant_kill = data.copy()
     data_cant_kill['name'] += '-but-cant'
 
-    re = requests.post(base_url + 'plans', json=data_cant_kill)
+    re = requests.post(base_url + 'plans', json=data_cant_kill, headers=username_header(sample_user))
     assert re.status_code == 201
     plan_id = re.content.strip()
     assert plan_id
@@ -1174,7 +1174,7 @@ def test_post_invalid_step_role(sample_user, sample_team, sample_template_name):
         ],
         'isValid': True
     }
-    re = requests.post(base_url + 'plans', json=data)
+    re = requests.post(base_url + 'plans', json=data, headers=username_header(sample_user))
     assert re.status_code == 400
     assert re.json() == {'description': 'Role oncall-primary is not appropriate for target %s in step 1' % sample_user, 'title': 'Invalid role'}
 
@@ -1200,12 +1200,12 @@ def test_post_invalid_step_role(sample_user, sample_team, sample_template_name):
         ],
         'isValid': True
     }
-    re = requests.post(base_url + 'plans', json=data)
+    re = requests.post(base_url + 'plans', json=data, headers=username_header(sample_user))
     assert re.status_code == 400
     assert re.json() == {'description': 'Role user is not appropriate for target %s in step 1' % sample_team, 'title': 'Invalid role'}
 
 
-def test_post_incident(sample_user, sample_team, sample_application_name, sample_template_name):
+def test_post_incident(sample_user, sample_team, sample_application_name, sample_template_name, superuser_application):
     data = {
         "creator": sample_user,
         "name": sample_user + "-test-incident-post",
@@ -1236,7 +1236,7 @@ def test_post_incident(sample_user, sample_team, sample_application_name, sample
         ],
         "isValid": True
     }
-    re = requests.post(base_url + 'plans', json=data)
+    re = requests.post(base_url + 'plans', json=data, headers=username_header(sample_user))
     assert re.status_code == 201
 
     re = requests.post(base_url + 'incidents', json={
@@ -1252,14 +1252,14 @@ def test_post_incident(sample_user, sample_team, sample_application_name, sample
         'owner': sample_user,
         'plan': sample_user + '-test-incident-post',
         'context': {},
-    }, headers={'Authorization': 'hmac %s:abc' % sample_application_name})
+    }, headers={'Authorization': 'hmac %s:abc' % superuser_application})
     assert re.status_code == 200
     assert re.json() == {'owner': sample_user, 'incident_id': incident_id, 'active': False}
 
     # Invalid claim owner
     re = requests.post(base_url + 'incidents/%d' % incident_id, json={
         'owner': invalid_user,
-    }, headers={'Authorization': 'hmac %s:abc' % sample_application_name})
+    }, headers={'Authorization': 'hmac %s:abc' % superuser_application})
     assert re.status_code == 400
     assert re.json()['title'] == 'Invalid claim: no matching owner'
 
@@ -1293,7 +1293,7 @@ def test_post_dynamic_incident(sample_user, sample_team, sample_application_name
         ],
         "isValid": True
     }
-    re = requests.post(base_url + 'plans', json=data)
+    re = requests.post(base_url + 'plans', json=data, headers=username_header(sample_user))
     assert re.status_code == 201
 
     # Create incident
@@ -1311,7 +1311,7 @@ def test_post_dynamic_incident(sample_user, sample_team, sample_application_name
     # Claim
     re = requests.post(base_url + 'incidents/%d' % (incident_id, ), json={
         'owner': sample_user,
-    }, headers={'Authorization': 'hmac %s:abc' % sample_application_name})
+    }, headers=username_header(sample_user))
     assert re.status_code == 200
     assert re.json() == {'owner': sample_user, 'incident_id': incident_id, 'active': False}
 
@@ -1374,11 +1374,11 @@ def test_post_incident_change_application(sample_user, sample_application_name, 
         'owner': sample_user,
         'plan': sample_user + '-test-incident-post',
         'context': {},
-    }, headers={'Authorization': 'hmac %s:abc' % sample_application_name})
+    }, headers={'Authorization': 'hmac %s:abc' % superuser_application})
     assert re.status_code == 200
     assert re.json() == {'owner': sample_user, 'incident_id': incident_id, 'active': False}
 
-    # sample_application_name2 is not allowed to make plans as sample_application_name, so this will fail
+    # sample_application_name2 is not allowed to make incidents as sample_application_name, so this will fail
     re = requests.post(base_url + 'incidents', json={
         'plan': sample_user + '-test-incident-post',
         'context': {},
@@ -1417,7 +1417,7 @@ def test_post_incident_without_apps(sample_user, sample_team, sample_template_na
         ],
         "isValid": True
     }
-    re = requests.post(base_url + 'plans', json=data)
+    re = requests.post(base_url + 'plans', json=data, headers=username_header(sample_user))
     assert re.status_code == 201
 
     # The application in sample_application_name2 does not have any sample_template_name templates, so this
@@ -1509,7 +1509,7 @@ def test_api_get_nested_context(sample_user, sample_team, sample_template_name, 
             ],
         ],
         'creator': sample_user,
-    })
+    }, headers=username_header(sample_user))
     assert re.status_code == 201
 
     ctx = {
@@ -1546,7 +1546,7 @@ def test_large_incident_context(sample_user, sample_application_name):
         'aggregation_reset': 1,
         'steps': [],
         'creator': sample_user,
-    })
+    }, headers=username_header(sample_user))
     assert re.status_code == 201
 
     ctx = {
@@ -1779,7 +1779,7 @@ def test_create_template(sample_user, sample_application_name):
         },
     }
 
-    re = requests.post(base_url + 'templates/', json=post_payload)
+    re = requests.post(base_url + 'templates/', json=post_payload, headers=username_header(sample_user))
     assert re.status_code == 201
     template_id = int(re.text)
 
@@ -2504,7 +2504,7 @@ def test_application_plans(sample_user, sample_template_name, sample_application
         "isValid": True
     }
     # Create plan
-    re = requests.post(base_url + 'plans', json=data)
+    re = requests.post(base_url + 'plans', json=data, headers=username_header(sample_user))
     assert re.status_code == 201
 
     # Check that plan appears for sample app 1


### PR DESCRIPTION
Also resolve HTTP splitting issue. Possibly a breaking change for existing apps that claim as a user or create incidents/plans as a user.