### PR TITLE
Fix aggregation queue leak

### DIFF
--- a/src/iris/bin/sender.py
+++ b/src/iris/bin/sender.py
@@ -553,7 +553,7 @@ def aggregate(now):
                 m['aggregated_ids'] = list(active_message_ids)
                 message_send_enqueue(m)
 
-                for message_id in active_message_ids:
+                for message_id in aggregated_message_ids:
                     messages.pop(message_id, None)
                 logger.info('[-] purged %s from messages %s remaining', active_message_ids, len(messages))
             del queues[key]
@@ -657,7 +657,7 @@ def fetch_and_prepare_message():
             # too many messages for the aggregation key - enqueue
 
             # add message id to aggregation queue
-            queues[key] = set([message_id])
+            queues.setdefault(key, set()).add(message_id)
             # add message id to queue for deduping
             messages[message_id] = m
             # initialize last sent tracker


### PR DESCRIPTION
Suppose our aggregation settings are: Aggregate after N messages in X minutes, stop aggregation after Y minutes without a message.

In fetch_and_prepare_message(), messages can both end aggregation (by being Y minutes from the last message sent with the aggregation key) and  also trigger aggregation (by being the Nth message in the last X minutes). This results in us overwriting the previous value of queues[key] on line 660, since
these messages haven't yet been sent in a batch.

By popping all aggregated_message_ids, not just active, we clear the message aggregation cache in the case where a message is deactivated before the aggregated message is sent. This may occur when an incident is claimed (possibly via "claim all") before aggregation has stopped
for that batch