### PR TITLE
Literal target notifications

### DIFF
--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -1867,6 +1867,10 @@ class Notifications(object):
         You can set the priority key to honor target's priority preference or
         set the mode key to force the message transport.
 
+        You can use the role "literal_target" to prevent unrolling of targets and
+        send messages directly to mailing lists or slack channels.
+        Note that if you use this role you MUST specify the mode key as well.
+
         **Example request**:
 
         .. sourcecode:: http

--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -1907,7 +1907,7 @@ class Notifications(object):
            Content-Type: application/json
 
            {
-               "role": "literal_user",
+               "role": "literal_target",
                "target": "#slackchannel",
                "subject": "wake up",
                "body": "something is on fire",

--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -1870,7 +1870,7 @@ class Notifications(object):
         You can use the role "literal_target" to prevent unrolling of targets and
         send messages directly to mailing lists or slack channels.
         Note that if you use this role you MUST specify the mode key but not the priority.
-        This role will set the destination to the target value without so make sure the target
+        This role will set the destination to the target value so make sure the target
         is a valid email address, slack channel, slack username, etc. 
 
         **Example request**:

--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -1869,7 +1869,9 @@ class Notifications(object):
 
         You can use the role "literal_target" to prevent unrolling of targets and
         send messages directly to mailing lists or slack channels.
-        Note that if you use this role you MUST specify the mode key as well.
+        Note that if you use this role you MUST specify the mode key but not the priority.
+        This role will set the destination to the target value without so make sure the target
+        is a valid email address, slack channel, slack username, etc. 
 
         **Example request**:
 
@@ -1897,6 +1899,19 @@ class Notifications(object):
                "subject": "wake up",
                "body": "something is on fire",
                "mode": "email"
+           }
+
+        .. sourcecode:: http
+
+           POST /v0/notifications HTTP/1.1
+           Content-Type: application/json
+
+           {
+               "role": "literal_user",
+               "target": "#slackchannel",
+               "subject": "wake up",
+               "body": "something is on fire",
+               "mode": "slack"
            }
 
         **Example response**:

--- a/src/iris/bin/sender.py
+++ b/src/iris/bin/sender.py
@@ -805,7 +805,7 @@ def set_target_contact(message):
             message['destination'] = cursor.fetchone()[0]
             cursor.close()
             connection.close()
-            result = True   
+            result = True
         else:
             # message triggered by incident will only have priority
             result = set_target_contact_by_priority(message)
@@ -1056,7 +1056,7 @@ def fetch_and_send_message(send_queue, vendor_manager):
         message = send_queue.get(True, 4)
     except queue.Empty:
         return
-    blame_str = 'app:%s  target:%s' % (message.get('application', '?'), message.get('target', '?')) 
+    blame_str = 'app:%s  target:%s' % (message.get('application', '?'), message.get('target', '?'))
 
     metrics.incr('send_queue_gets_cnt')
 

--- a/src/iris/sender/rpc.py
+++ b/src/iris/sender/rpc.py
@@ -93,12 +93,12 @@ def handle_api_notification_request(socket, address, req):
     # if role is literal_target skip unrolling
     if role == 'literal_target':
         # target_literal requires that a mode be set and no priority be defined
-        if not notification.get('mode'):
+        if 'mode' not in notification:
             reject_api_request(socket, address, 'INVALID mode not set for literal_target role')
             logger.warn('Dropping OOB message with invalid role:mode from app %s',
                         notification['application'])
             return
-        if notification.get('priority'):
+        if 'priority' in notification:
             reject_api_request(socket, address, 'INVALID role literal_target does not support priority')
             logger.warn('Dropping OOB message with invalid role:priority from app %s',
                         notification['application'])

--- a/src/iris/sender/rpc.py
+++ b/src/iris/sender/rpc.py
@@ -89,8 +89,7 @@ def handle_api_notification_request(socket, address, req):
         logger.warn('Dropping OOB message with invalid target "%s" from app %s',
                     target, notification['application'])
         return
-    expanded_targets = target
-
+    expanded_targets = None
     # if role is literal_target skip unrolling
     if role == 'literal_target':
         # target_literal requires that a mode be set and no priority be defined
@@ -144,10 +143,13 @@ def handle_api_notification_request(socket, address, req):
                        address, role, target, notification['application'],
                        notification.get('priority', notification.get('mode', '?')))
 
-    for _target in expanded_targets:
-        temp_notification = notification.copy()
-        temp_notification['target'] = _target
-        send_funcs['message_send_enqueue'](temp_notification)
+    if role == 'literal_target':
+        send_funcs['message_send_enqueue'](notification)
+    else:
+        for _target in expanded_targets:
+            temp_notification = notification.copy()
+            temp_notification['target'] = _target
+            send_funcs['message_send_enqueue'](temp_notification)
     metrics.incr('notification_cnt')
     socket.sendall(msgpack.packb('OK'))
 

--- a/test/e2etest.py
+++ b/test/e2etest.py
@@ -2271,6 +2271,28 @@ def test_post_invalid_notification(sample_user, sample_application_name):
     assert re.json()['description'] == 'INVALID role:target'
 
     re = requests.post(base_url + 'notifications', json={
+        'role': 'literal_target',
+        'target': 'sample_mailinglist@email.com',
+        'subject': 'test',
+        'priority': 'low',
+        'body': 'foo'
+    }, headers={'authorization': 'hmac %s:boop' % sample_application_name})
+    assert re.status_code == 400
+    assert re.json()['description'] == 'INVALID mode not set for literal_target role'
+
+    re = requests.post(base_url + 'notifications', json={
+        'role': 'literal_target',
+        'target': 'sample_mailinglist@email.com',
+        'subject': 'test',
+        'mode': 'email',
+        'priority': 'low',
+        'email_html': 'foobar',
+        'body': '',
+    }, headers={'authorization': 'hmac %s:boop' % sample_application_name})
+    assert re.status_code == 400
+    assert re.json()['description'] == 'INVALID role literal_target does not support priority'
+
+    re = requests.post(base_url + 'notifications', json={
         'mode': 'email',
         'role': 'user',
         'target': sample_user,
@@ -2317,6 +2339,17 @@ def test_post_notification(sample_user, sample_application_name):
         'target': sample_user,
         'subject': 'test',
         'priority': 'low',
+        'mode': 'email',
+        'email_html': 'foobar',
+        'body': '',
+    }, headers={'authorization': 'hmac %s:boop' % sample_application_name})
+    assert re.status_code == 200
+    assert re.text == '[]'
+
+    re = requests.post(base_url + 'notifications', json={
+        'role': 'literal_target',
+        'target': 'sample_mailinglist@email.com',
+        'subject': 'test',
         'mode': 'email',
         'email_html': 'foobar',
         'body': '',


### PR DESCRIPTION
A notification sent using the new "literal_target" role will skip the target unrolling process and instead use the provided target as its destination. This introduces the ability to send notifications to any arbitrary email address (including mailing lists), slack recipient (including channels), and numbers. 