### PR TITLE
Fixing quotation marks in quickstart.rst

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -50,9 +50,9 @@ turn off the ``ONLY_FULL_GROUP_BY`` MySQL mode.
 
 .. code:: sql
 
-    CREATE USER ‘iris’@’localhost’ IDENTIFIED BY ‘iris’
-    CREATE DATABASE iris
-    GRANT ALL ON iris.* TO iris@localhost
+    CREATE USER 'iris'@'localhost' IDENTIFIED BY 'iris';
+    CREATE DATABASE iris;
+    GRANT ALL ON iris.* TO iris@localhost;
     SET GLOBAL sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''));
 
 Now let’s load the schema and some dummy data. Navigate to project root,


### PR DESCRIPTION
The existing quotes will get removed when copying and pasting into mysql prompt, causing the below error to be shown:
```sql
mysql> CREATE USER iris@localhost IDENTIFIED BY iris;
ERROR 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'iris' at line 1
mysql> 

```