### PR TITLE
grafana webhook support

### DIFF
--- a/docs/source/admin_manual.rst
+++ b/docs/source/admin_manual.rst
@@ -17,6 +17,7 @@ Service Integration
 .. toctree::
    nagios
    alertmanager
+   grafana
 
 
 Iris components

--- a/docs/source/grafana.rst
+++ b/docs/source/grafana.rst
@@ -1,0 +1,35 @@
+Grafana Integration
+========================
+
+Iris can easily be integrated into an existing Grafana implementation.
+
+==================
+Iris Configuration
+==================
+
+Enable the builtin Grafana webhook in Iris' configuration.
+
+Configuration::
+
+    webhooks:
+      - grafana
+
+Then create an application using the UI. In this example let's use the name 'grafana'.
+Once you've created the application you'll be able to retrieve the application's key.
+Here we'll use "abc".
+
+==========================
+Grafana Configuration
+==========================
+
+In Grafana, you can configure Iris as a notifcation channel, using the application, it's key
+and the target plan as parameters in the webhook url.
+
+Configuration::
+
+    Name: iris-team1
+    Type: webhook
+    Url: http://iris:16649/v0/webhooks/grafana?application=grafana&key=abc&plan=team1
+    Http Method: POST
+
+Then simply add this notification channel to your alert in Grafana.

--- a/src/iris/webhooks/grafana.py
+++ b/src/iris/webhooks/grafana.py
@@ -1,0 +1,87 @@
+from __future__ import absolute_import
+
+import datetime
+import logging
+import ujson
+from falcon import HTTP_201, HTTPBadRequest, HTTPInvalidParam
+
+from iris import db
+
+logger = logging.getLogger(__name__)
+
+
+class grafana(object):
+    allow_read_no_auth = False
+
+    def validate_post(self, body):
+        if not all(k in body for k in("ruleName", "state", "message")):
+            raise HTTPBadRequest('missing ruleName, state and/or message attributes')
+
+    def create_context(self, body):
+        context_json_str = ujson.dumps(body)
+        if len(context_json_str) > 65535:
+            logger.warn('POST to grafana exceeded acceptable size')
+            raise HTTPBadRequest('Context too long')
+
+        return context_json_str
+
+    def on_post(self, req, resp):
+        '''
+        This endpoint is compatible with the webhook post from Grafana.
+        Simply configure Grafana with a new notification channel with type 'webhook'
+        and a plan parameter pointing to your iris plan.
+
+        Name: 'iris-team1'
+        Url: http://iris:16649/v0/webhooks/grafana?application=test-app&key=sdffdssdf&plan=team1
+        '''
+        alert_params = ujson.loads(req.context['body'])
+        self.validate_post(alert_params)
+
+        with db.guarded_session() as session:
+            plan = req.get_param('plan', True)
+            plan_id = session.execute('SELECT `plan_id` FROM `plan_active` WHERE `name` = :plan',
+                                      {'plan': plan}).scalar()
+            if not plan_id:
+                logger.warn('No active plan "%s" found', plan)
+                raise HTTPInvalidParam('plan does not exist or is not active')
+
+            app = req.context['app']
+
+            context_json_str = self.create_context(alert_params)
+
+            app_template_count = session.execute('''
+                SELECT EXISTS (
+                  SELECT 1 FROM
+                  `plan_notification`
+                  JOIN `template` ON `template`.`name` = `plan_notification`.`template`
+                  JOIN `template_content` ON `template_content`.`template_id` = `template`.`id`
+                  WHERE `plan_notification`.`plan_id` = :plan_id
+                  AND `template_content`.`application_id` = :app_id
+                )
+            ''', {'app_id': app['id'], 'plan_id': plan_id}).scalar()
+
+            if not app_template_count:
+                logger.warn('no plan template exists for this app')
+                raise HTTPBadRequest('No plan template actions exist for this app')
+
+            data = {
+                'plan_id': plan_id,
+                'created': datetime.datetime.utcnow(),
+                'application_id': app['id'],
+                'context': context_json_str,
+                'current_step': 0,
+                'active': True,
+            }
+
+            incident_id = session.execute(
+                '''INSERT INTO `incident` (`plan_id`, `created`, `context`,
+                                           `current_step`, `active`, `application_id`)
+                   VALUES (:plan_id, :created, :context, 0, :active, :application_id)''',
+                data).lastrowid
+
+            session.commit()
+            session.close()
+
+        resp.status = HTTP_201
+        resp.set_header('Location', '/incidents/%s' % incident_id)
+        resp.body = ujson.dumps(incident_id)

--- a/test/test_webhook_grafana.py
+++ b/test/test_webhook_grafana.py
@@ -1,0 +1,57 @@
+# Copyright (c) LinkedIn Corporation. All rights reserved. Licensed under the BSD-2 Clause license.
+# See LICENSE in the project root for license information.
+
+from falcon import HTTPBadRequest
+
+
+def test_parse_valid_body():
+    from iris.webhooks.grafana import grafana
+    grafana_webhook = grafana()
+
+    fake_post = {
+        "evalMatches": [{
+            "value": 100,
+            "metric": "High value",
+            "tags": "",
+        }, {
+            "value": 200,
+            "metric": "Higher Value",
+            "tags": "",
+        }],
+        "imageUrl": "http://grafana.org/assets/img/blog/mixed_styles.png",
+        "message": "Someone is testing the alert notification within grafana.",
+        "ruleId": 0,
+        "ruleName": "Test notification",
+        "ruleUrl": "https://grafana.org/",
+        "state": "alerting",
+        "title": "[Alerting] Test notification"
+    }
+    grafana_webhook.validate_post(fake_post)
+
+
+def test_parse_invalid_body():
+    from iris.webhooks.grafana import grafana
+    grafana_webhook = grafana()
+
+    fake_post = {
+        "evalMatches": [{
+            "value": 100,
+            "metric": "High value",
+            "tags": "",
+        }, {
+            "value": 200,
+            "metric": "Higher Value",
+            "tags": "",
+        }],
+        "imageUrl": "http://grafana.org/assets/img/blog/mixed_styles.png",
+        "message": "Someone is testing the alert notification within grafana.",
+        "ruleId": 0,
+        "ruleName": "Test notification",
+        "ruleUrl": "https://grafana.org/",
+        "state": "alerting",
+        "title": "[Alerting] Test notification"
+    }
+    try:
+        grafana_webhook.validate_post(fake_post)
+    except HTTPBadRequest:
+        pass


### PR DESCRIPTION
Adds a new webhook to natively support using Iris as a notification channel in Grafana, using the 'webhook' type.