### PR TITLE
add Date header to please spamassassin

### DIFF
--- a/src/iris/vendors/iris_smtp.py
+++ b/src/iris/vendors/iris_smtp.py
@@ -6,6 +6,7 @@ from iris.constants import EMAIL_SUPPORT, IM_SUPPORT
 from smtplib import SMTP
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
+from email.utils import formatdate
 import quopri
 import time
 import markdown
@@ -76,6 +77,7 @@ class iris_smtp(object):
         if incident_id:
             m['X-IRIS-INCIDENT-ID'] = str(incident_id)
 
+        m['Date'] = formatdate(localtime=True)
         m['from'] = from_address
         m['to'] = message['destination']
         if message.get('noreply'):


### PR DESCRIPTION
Spamassassin is very critical of mails coming from Iris. One of the biggest score contributor was lack of a Date header.

https://wiki.apache.org/spamassassin/Rules/MISSING_DATE