### PR TITLE
allow missing message field, just like grafana

### DIFF
--- a/src/iris/webhooks/grafana.py
+++ b/src/iris/webhooks/grafana.py
@@ -14,8 +14,9 @@ class grafana(object):
     allow_read_no_auth = False
 
     def validate_post(self, body):
-        if not all(k in body for k in("ruleName", "state", "message")):
-            raise HTTPBadRequest('missing ruleName, state and/or message attributes')
+        if not all(k in body for k in("ruleName", "state")):
+            logger.warn('missing ruleName and/or state attributes')
+            raise HTTPBadRequest('missing ruleName and/of state attributes')
 
     def create_context(self, body):
         context_json_str = ujson.dumps(body)

--- a/test/test_webhook_grafana.py
+++ b/test/test_webhook_grafana.py
@@ -45,10 +45,10 @@ def test_parse_invalid_body():
             "tags": "",
         }],
         "imageUrl": "http://grafana.org/assets/img/blog/mixed_styles.png",
+        "message": "Someone is testing the alert notification within grafana.",
         "ruleId": 0,
         "ruleName": "Test notification",
         "ruleUrl": "https://grafana.org/",
-        "state": "alerting",
         "title": "[Alerting] Test notification"
     }
 


### PR DESCRIPTION
Some users fail to use the Message field in a Grafana alert. Grafana is fine with this however. Changing the webhook to comply.