### PR TITLE
Bump twilio python to modern version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
         'streql==3.0.2',
         'dnspython==1.16.0',
         'phonenumbers==7.4.1',
-        'twilio==4.5.0',
+        'twilio==6.25.0',
         'google-api-python-client==1.4.2',
         'oauth2client==1.4.12',
         'slackclient==0.16',

--- a/test/test_iris_vendor_twilio.py
+++ b/test/test_iris_vendor_twilio.py
@@ -3,7 +3,6 @@
 
 
 def test_twilio_message_generate(mocker):
-    mocker.patch('twilio.rest.resources.Connection')
     from iris.vendors.iris_twilio import iris_twilio
     twilio = iris_twilio({})
     assert twilio.generate_message_text({}) == ''
@@ -14,7 +13,6 @@ def test_twilio_message_generate(mocker):
 
 
 def test_twilio_notification_call_generate(mocker):
-    mocker.patch('twilio.rest.resources.Connection')
     mocker.patch('iris.vendors.iris_twilio.find_plugin')
     from iris.vendors.iris_twilio import iris_twilio
     relay_base_url = 'http://foo/relay'
@@ -45,7 +43,6 @@ def test_twilio_notification_call_generate(mocker):
 
 
 def test_twilio_incident_call_generate(mocker):
-    mocker.patch('twilio.rest.resources.Connection')
     mock_plugin = mocker.MagicMock()
     mock_plugin.get_phone_menu_text.return_value = 'Press 1 to pay'
     mocker.patch('iris.vendors.iris_twilio.find_plugin').return_value = mock_plugin


### PR DESCRIPTION
Update the way we handle proxy settings
Timeouts now require superclassing and replacing Twilio's http client.