### PR TITLE
fix front end time display and round down stats time to the nearest hour

### DIFF
--- a/src/iris/app_stats.py
+++ b/src/iris/app_stats.py
@@ -1,5 +1,5 @@
 import time
-from datetime import datetime, timedelta
+from datetime import datetime
 from collections import defaultdict
 import logging
 
@@ -76,10 +76,11 @@ def calculate_app_stats(app, connection, cursor, fields_filter=None):
         fields &= set(fields_filter)
 
     for delta in range(0, 7):
-        now = datetime.utcnow() - timedelta(weeks=delta)
-        formatted_date = now.strftime('%Y-%m-%d %H:%M:%S')
+        # 3600 seconds in an hour, round down to the nearest hour
         # 604800 seconds in a week, shift date by delta number of weeks
-        unix_date = int(time.time()) - (delta * 604800)
+        unix_date = int(time.time() // 3600 * 3600) - (delta * 604800)
+        now = datetime.fromtimestamp(unix_date)
+        formatted_date = now.strftime('%Y-%m-%d %H:%M:%S')
         query_data = {'application_id': app['id'], 'date_variable': formatted_date}
 
         for key in fields:
@@ -207,10 +208,11 @@ def calculate_single_stat(connection, cursor, stat_name):
     stats = {}
 
     for delta in range(0, 7):
-        now = datetime.utcnow() - timedelta(weeks=delta)
-        formatted_date = now.strftime('%Y-%m-%d %H:%M:%S')
+        # 3600 seconds in an hour, round down to the nearest hour
         # 604800 seconds in a week, shift date by delta number of weeks
-        unix_date = int(time.time()) - (delta * 604800)
+        unix_date = int(time.time() // 3600 * 3600) - (delta * 604800)
+        now = datetime.fromtimestamp(unix_date)
+        formatted_date = now.strftime('%Y-%m-%d %H:%M:%S')
         stats[unix_date] = []
 
         row_count = cursor.execute(queries[stat_name], {'date_variable': formatted_date})
@@ -269,10 +271,11 @@ def calculate_global_stats(connection, cursor, fields_filter=None):
 
     for delta in range(0, 7):
 
-        now = datetime.utcnow() - timedelta(weeks=delta)
-        formatted_date = now.strftime('%Y-%m-%d %H:%M:%S')
+        # 3600 seconds in an hour, round down to the nearest hour
         # 604800 seconds in a week, shift date by delta number of weeks
-        unix_date = int(time.time()) - (delta * 604800)
+        unix_date = int(time.time() // 3600 * 3600) - (delta * 604800)
+        now = datetime.fromtimestamp(unix_date)
+        formatted_date = now.strftime('%Y-%m-%d %H:%M:%S')
 
         for key in fields:
             start = time.time()

--- a/src/iris/ui/static/js/iris.js
+++ b/src/iris/ui/static/js/iris.js
@@ -3211,8 +3211,11 @@ iris = {
         var month = months[a.getMonth()];
         var date = a.getDate();
         var hour = a.getHours();
+        if(hour == '0'){hour = '00'}
         var min = a.getMinutes();
+        if(min == '0'){min = '00'}
         var sec = a.getSeconds();
+        if(sec == '0'){sec = '00'}
         var time = date + ' ' + month + ' ' + year + ' ' + hour + ':' + min + ':' + sec ;
         return time;
       } else {

--- a/src/iris/ui/static/js/iris.js
+++ b/src/iris/ui/static/js/iris.js
@@ -3211,11 +3211,11 @@ iris = {
         var month = months[a.getMonth()];
         var date = a.getDate();
         var hour = a.getHours();
-        if(hour == '0'){hour = '00'}
+        if(hour < 10){hour = '0' + hour}
         var min = a.getMinutes();
-        if(min == '0'){min = '00'}
+        if(min < 10){min = '0' + min}
         var sec = a.getSeconds();
-        if(sec == '0'){sec = '00'}
+        if(sec < 10){sec = '0' + sec}
         var time = date + ' ' + month + ' ' + year + ' ' + hour + ':' + min + ':' + sec ;
         return time;
       } else {


### PR DESCRIPTION
- Fix handlebars helper so that it displays 12:00:00 instead of 12:0:0. 
- Round down to the nearest hour for stats calculation so that the stats for all apps have consistent timestamps. 