### PR TITLE
Change calls to Chinese numbers to sms

### DIFF
--- a/src/iris/bin/sender.py
+++ b/src/iris/bin/sender.py
@@ -1441,6 +1441,18 @@ def sender_shutdown():
     os._exit(0)
 
 
+def check_call_restrictions(message):
+    # check for known corner cases in message delivery and correct accordingly
+
+    # due to calling restrictions to china override mode and send as sms instead
+    if message['destination'].startswith('+86'):
+        message['mode'] = 'sms'
+        # this message will appear before the contents of the sms template
+        message['body'] = '''Due to legal restrictions we are unable to deliver calls to China. Please check Iris for complete incident details and change your settings to use sms, slack, or email instead - '''
+
+    return message['mode'], message['body']
+
+
 def message_send_enqueue(message):
 
     # If this message has an ID, avoid queueing it twice, assuming it's not a retry
@@ -1462,6 +1474,12 @@ def message_send_enqueue(message):
 
     message_mode = message.get('mode')
     if message_mode and message_mode in per_mode_send_queues:
+        # check for known corner case limitations and correct accordingly
+        if message['mode'] == 'call':
+            message_mode, message_body = check_call_restrictions(message)
+            message['mode'] = message_mode
+            message['body'] = message_body
+
         if message_id is not None:
             message_ids_being_sent.add(message_id)
         per_mode_send_queues[message_mode].put(message)

--- a/src/iris/bin/sender.py
+++ b/src/iris/bin/sender.py
@@ -1448,10 +1448,10 @@ def modify_restricted_calls(message):
     if message['destination'].startswith('+86'):
         message['mode'] = 'sms'
         auditlog.message_change(
-                message['message_id'], auditlog.MODE_CHANGE, 'call', 'sms',
-                'Changing mode due to calling restriction')
+            message['message_id'], auditlog.MODE_CHANGE, 'call', 'sms',
+            'Changing mode due to calling restriction')
         # this message will appear before the contents of the sms template
-        message['body'] = message.get('body', '') + ' - Due to legal restrictions we are unable to deliver calls to China. Please check Iris for complete incident details and change your settings to use sms, slack, or email instead - '
+        message['body'] = 'Due to legal restrictions we are unable to deliver calls to China. Please check Iris for complete incident details and change your settings to use sms, slack, or email instead - ' + message.get('body', '')
 
 
 def message_send_enqueue(message):


### PR DESCRIPTION
Due to calling limitations for china change calls made to Chinese numbers to use sms instead. https://support.twilio.com/hc/en-us/articles/360016488474-Calling-Limitations-to-China