### PR TITLE
Add support for multi-recipient email notifications

### DIFF
--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -2028,7 +2028,10 @@ class Notifications(object):
 
         A request is considered invalid if:
 
-        - either target, subject or role is missing
+        - either target, subject or role is missing and target_list is not provided
+        - target_list is provided, but no subject
+        - target_list is malformed (not of the form [{"role": foo, "target": bar}])
+        - a priority is given for a target_list
         - both priority and mode are missing
         - invalid priority, mode
         - both tempalte, body and email_html are missing
@@ -2039,30 +2042,46 @@ class Notifications(object):
         message = ujson.loads(req.context['body'])
         msg_attrs = set(message)
         if not msg_attrs >= self.required_attrs:
-            raise HTTPBadRequest('Missing required atrributes',
-                                 ', '.join(self.required_attrs - msg_attrs))
+            if 'target_list' not in msg_attrs:
+                raise HTTPBadRequest('Missing required atrributes',
+                                     ', '.join(self.required_attrs - msg_attrs))
+            else:
+                if 'subject' not in msg_attrs:
+                    raise HTTPBadRequest('Missing required atrributes: subject')
+                if not all(['role' in t and 'target' in t for t in message['target_list']]):
+                    raise HTTPBadRequest('Malformed target list')
 
-        # If both priority and mode are passed in, priority overrides mode
-        if 'priority' in message:
-            priority = cache.priorities.get(message['priority'])
-            if not priority:
-                raise HTTPBadRequest('Invalid priority', message['priority'])
-            message['priority_id'] = priority['id']
-        elif 'mode' in message:
-            mode_id = cache.modes.get(message['mode'])
-            if not mode_id:
-                raise HTTPBadRequest('Invalid mode', message['mode'])
-            message['mode_id'] = mode_id
+        if 'target_list' in message:
+            message['multi-recipient'] = True
+            if 'mode' in message:
+                mode_id = cache.modes.get(message['mode'])
+                if not mode_id or message['mode'] != 'email':
+                    raise HTTPBadRequest('Invalid mode', message['mode'])
+                message['mode_id'] = mode_id
+            else:
+                raise HTTPBadRequest('Contact mode required for target list')
         else:
-            raise HTTPBadRequest(
-                'Both priority and mode are missing, at least one of it is required')
-        if message['role'] == 'literal_target':
-            # target_literal requires that a mode be set and no priority be defined
-            if 'mode' not in message:
-                raise HTTPBadRequest('INVALID mode not set for literal_target role')
+            # If both priority and mode are passed in, priority overrides mode
             if 'priority' in message:
-                raise HTTPBadRequest('INVALID role literal_target does not support priority')
-            message['unexpanded'] = True
+                priority = cache.priorities.get(message['priority'])
+                if not priority:
+                    raise HTTPBadRequest('Invalid priority', message['priority'])
+                message['priority_id'] = priority['id']
+            elif 'mode' in message:
+                mode_id = cache.modes.get(message['mode'])
+                if not mode_id:
+                    raise HTTPBadRequest('Invalid mode', message['mode'])
+                message['mode_id'] = mode_id
+            else:
+                raise HTTPBadRequest(
+                    'Both priority and mode are missing, at least one of it is required')
+            if message['role'] == 'literal_target':
+                # target_literal requires that a mode be set and no priority be defined
+                if 'mode' not in message:
+                    raise HTTPBadRequest('INVALID mode not set for literal_target role')
+                if 'priority' in message:
+                    raise HTTPBadRequest('INVALID role literal_target does not support priority')
+                message['unexpanded'] = True
 
         # Avoid problems down the line if we have no way of creating the
         # message body, which happens if both body and template are not

--- a/src/iris/bin/sender.py
+++ b/src/iris/bin/sender.py
@@ -783,25 +783,41 @@ def set_target_contact_by_priority(message):
 
 def set_target_contact(message):
     # If we already have a destination set (eg incident tracking emails or literal_target notifications) no-op this
-    if 'destination' in message:
+    if 'destination' in message and not message.get('multi-recipient'):
         return True
 
     # returns True if contact has been set (even if it has been changed to the fallback). Otherwise, returns False
-    try:
-        if 'mode' in message or 'mode_id' in message:
-            # for out of band notification, we already have the mode *OR*
-            # mode_id set by API
-            connection = db.engine.raw_connection()
-            cursor = connection.cursor()
-            cursor.execute('''
+    destination_query = '''
                 SELECT `destination` FROM `target_contact`
                 JOIN `target` ON `target`.`id` = `target_contact`.`target_id`
                 JOIN `target_type` on `target_type`.`id` = `target`.`type_id`
                 WHERE `target`.`name` = %(target)s
                 AND `target_type`.`name` = 'user'
                 AND (`target_contact`.`mode_id` = %(mode_id)s OR `target_contact`.`mode_id` = (SELECT `id` FROM `mode` WHERE `name` = %(mode)s))
-                LIMIT 1
-                ''', {'target': message['target'], 'mode_id': message.get('mode_id'), 'mode': message.get('mode')})
+                LIMIT 1'''
+
+    # Handle multi-recipient messages. These are only allowed when mode is specified, not priority.
+    # Return True if we're able to resolve at least one target
+    if message.get('multi-recipient'):
+        connection = db.engine.raw_connection()
+        cursor = connection.cursor()
+        for t in message['target']:
+            try:
+                cursor.execute(destination_query, {'target': t, 'mode_id': message.get('mode_id'), 'mode': message.get('mode')})
+                message['destination'].append(cursor.fetchone()[0])
+            except (ValueError, TypeError):
+                continue
+        cursor.close()
+        connection.close()
+        return bool(message.get('destination'))
+
+    try:
+        if 'mode' in message or 'mode_id' in message:
+            # for out of band notification, we already have the mode *OR*
+            # mode_id set by API
+            connection = db.engine.raw_connection()
+            cursor = connection.cursor()
+            cursor.execute(destination_query, {'target': message['target'], 'mode_id': message.get('mode_id'), 'mode': message.get('mode')})
             message['destination'] = cursor.fetchone()[0]
             cursor.close()
             connection.close()
@@ -1041,9 +1057,10 @@ def distributed_send_message(message, vendor_manager):
 
     # application is not present for incident tracking emails
     if 'application' in message:
+        notification_count = 1 if not message.get('target_list') else len(message['destination'])
         metrics_key = 'app_%(application)s_mode_%(mode)s_cnt' % message
         metrics.add_new_metrics({metrics_key: 0})
-        metrics.incr(metrics_key)
+        metrics.incr(metrics_key, inc=notification_count)
 
     if runtime is not None:
         return True, True

--- a/src/iris/sender/rpc.py
+++ b/src/iris/sender/rpc.py
@@ -93,6 +93,7 @@ def handle_api_notification_request(socket, address, req):
     if not notification.get('unexpanded'):
         # For multi-recipient notifications, pre-populate destination with literal targets,
         # then expand the remaining
+        has_literal_target = False
         if target_list:
             expanded_targets = []
             notification['destination'] = []
@@ -102,6 +103,7 @@ def handle_api_notification_request(socket, address, req):
                 try:
                     if role == 'literal_target':
                         notification['destination'].append(target)
+                        has_literal_target = True
                     else:
                         expanded = cache.targets_for_role(role, target)
                         expanded_targets += [e for e in expanded]
@@ -113,7 +115,7 @@ def handle_api_notification_request(socket, address, req):
                 expanded_targets = cache.targets_for_role(role, target)
             except IrisRoleLookupException:
                 expanded_targets = None
-        if not expanded_targets:
+        if not expanded_targets and not has_literal_target:
             reject_api_request(socket, address, 'INVALID role:target')
             logger.warn('Dropping OOB message with invalid role:target "%s:%s" from app %s',
                         role, target, notification['application'])

--- a/test/e2etest.py
+++ b/test/e2etest.py
@@ -2348,6 +2348,7 @@ def test_post_notification(sample_user, sample_team, sample_application_name):
     assert re.status_code == 200
     assert re.text == '[]'
 
+    # Multi-recipent notification should succeed
     re = requests.post(base_url + 'notifications', json={
         'target_list': [{'role': 'user', 'target': sample_user},
                         {'role': 'team', 'target': sample_team},
@@ -2359,6 +2360,29 @@ def test_post_notification(sample_user, sample_team, sample_application_name):
     assert re.status_code == 200
     assert re.text == '[]'
 
+    # Multi-recipent notification with all literal targets should succeed
+    re = requests.post(base_url + 'notifications', json={
+        'target_list': [{'role': 'literal_target', 'target': 'barbaz@example.com'},
+                        {'role': 'literal_target', 'target': 'foobar@example.com'}],
+        'subject': 'test',
+        'mode': 'email',
+        'body': 'foo'
+    }, headers={'authorization': 'hmac %s:boop' % sample_application_name})
+    assert re.status_code == 200
+    assert re.text == '[]'
+
+    # Multi-recipent notification with one invalid target should still succeed
+    re = requests.post(base_url + 'notifications', json={
+        'target_list': [{'role': 'user', 'target': 'invalid-user-foobar'},
+                        {'role': 'user', 'target': sample_user}],
+        'subject': 'test',
+        'mode': 'email',
+        'body': 'foo'
+    }, headers={'authorization': 'hmac %s:boop' % sample_application_name})
+    assert re.status_code == 200
+    assert re.text == '[]'
+
+    # Should return 400 for multi-recipient notification specifying priority
     re = requests.post(base_url + 'notifications', json={
         'target_list': [{'role': 'user', 'target': sample_user},
                         {'role': 'team', 'target': sample_team},
@@ -2369,6 +2393,7 @@ def test_post_notification(sample_user, sample_team, sample_application_name):
     }, headers={'authorization': 'hmac %s:boop' % sample_application_name})
     assert re.status_code == 400
 
+    # Should return 400 for multi-recipient notification with missing subject
     re = requests.post(base_url + 'notifications', json={
         'target_list': [{'role': 'user', 'target': sample_user},
                         {'role': 'team', 'target': sample_team},

--- a/test/e2etest.py
+++ b/test/e2etest.py
@@ -2294,7 +2294,7 @@ def test_post_invalid_notification(sample_user, sample_application_name):
     assert 'email_html needs to be a string' in re.text
 
 
-def test_post_notification(sample_user, sample_application_name):
+def test_post_notification(sample_user, sample_team, sample_application_name):
     # The iris-api in this case will send a request to iris-sender's
     # rpc endpoint. Don't bother if sender isn't working.
     try:
@@ -2347,6 +2347,35 @@ def test_post_notification(sample_user, sample_application_name):
     }, headers={'authorization': 'hmac %s:boop' % sample_application_name})
     assert re.status_code == 200
     assert re.text == '[]'
+
+    re = requests.post(base_url + 'notifications', json={
+        'target_list': [{'role': 'user', 'target': sample_user},
+                        {'role': 'team', 'target': sample_team},
+                        {'role': 'literal_target', 'target': 'foobar@example.com'}],
+        'subject': 'test',
+        'mode': 'email',
+        'body': 'foo'
+    }, headers={'authorization': 'hmac %s:boop' % sample_application_name})
+    assert re.status_code == 200
+    assert re.text == '[]'
+
+    re = requests.post(base_url + 'notifications', json={
+        'target_list': [{'role': 'user', 'target': sample_user},
+                        {'role': 'team', 'target': sample_team},
+                        {'role': 'literal_target', 'target': 'foobar@example.com'}],
+        'subject': 'test',
+        'priority': 'low',
+        'body': 'foo'
+    }, headers={'authorization': 'hmac %s:boop' % sample_application_name})
+    assert re.status_code == 400
+
+    re = requests.post(base_url + 'notifications', json={
+        'target_list': [{'role': 'user', 'target': sample_user},
+                        {'role': 'team', 'target': sample_team},
+                        {'role': 'literal_target', 'target': 'foobar@example.com'}],
+        'body': 'foo'
+    }, headers={'authorization': 'hmac %s:boop' % sample_application_name})
+    assert re.status_code == 400
 
 
 def test_modify_applicaton_quota(sample_application_name, sample_admin_user, sample_plan_name):


### PR DESCRIPTION
This way, batch emails can be sent without hitting the API each
time. Instead, we send a single email with a list of recipients.
Note that this is currently supported only for out-of-band notifications
that specifically specify email as a contact mode, and does
not support priorities (where messages may be split across many
different contact modes).