### PR TITLE
Fix retries by catching the correct exception

### DIFF
--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -19,10 +19,9 @@ from falcon import (HTTP_200, HTTP_201, HTTP_204, HTTPBadRequest,
                     HTTPNotFound, HTTPUnauthorized, HTTPForbidden, HTTPFound,
                     HTTPInternalServerError, API)
 from falcon_cors import CORS
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import IntegrityError, InternalError
 import falcon.uri
 import falcon
-import pymysql.err
 
 from collections import defaultdict
 from streql import equals
@@ -1704,7 +1703,7 @@ class Incidents(object):
 
                     session.commit()
                     session.close()
-                except pymysql.err.InternalError:
+                except InternalError:
                     logger.exception('Failed inserting incident. (Try %s/%s)', retries, max_retries)
                     if retries < max_retries:
                         sleep(.2)


### PR DESCRIPTION
The pymysql InternalError is the underyling exception, but it gets reraised
as a rebranded sqlalchemy exception.