### PR TITLE
purge caches every sender loop and retry auditlog

### DIFF
--- a/src/iris/bin/sender.py
+++ b/src/iris/bin/sender.py
@@ -381,7 +381,7 @@ def create_messages(msg_info):
                                            (plan_notification['plan_id'], plan_notification_id, incident_id,
                                             application_id, target_id, priority_id, body))
                             connection.commit()
-                        except InternalError:
+                        except Exception:
                             logger.exception('Failed inserting message for incident %s. (Try %s/%s)', incident_id, retries, max_retries)
                             if retries < max_retries:
                                 sleep(.2)
@@ -411,7 +411,7 @@ def create_messages(msg_info):
                 msg_sql = BATCH_INSERT_MESSAGE_QUERY + ','.join('(NOW(), %s,%s,%s,%s,%s,%s,%s)' for i in range(values_count))
                 cursor.execute(msg_sql, query_params)
                 connection.commit()
-            except InternalError:
+            except Exception:
                 logger.exception('Failed inserting batch messages for incident %s. (Try %s/%s)', incident_id, retries, max_retries)
                 if retries < max_retries:
                     sleep(.2)

--- a/src/iris/sender/auditlog.py
+++ b/src/iris/sender/auditlog.py
@@ -2,6 +2,7 @@
 # See LICENSE in the project root for license information.
 
 from .. import db
+from gevent import sleep
 import logging
 logger = logging.getLogger(__name__)
 
@@ -15,11 +16,27 @@ def message_change(message_id, change_type, old, new, description):
         logger.warn('Not logging %s for message as it does not have an id', change_type)
         return
 
-    session = db.Session()
-    session.execute('''
-      INSERT INTO `message_changelog` (`message_id`, `change_type`, `old`, `new`, `description`, `date`)
-      VALUES (:message_id, :change_type, :old, :new, :description, NOW())
-    ''', dict(message_id=message_id, change_type=change_type, old=old, new=new, description=description))
-    session.commit()
-    session.close()
-    logger.info('Logged change information for message (ID %s)', message_id)
+    # retry to guard against deadlocks
+    retries = 0
+    max_retries = 5
+    while True:
+        with db.guarded_session() as session:
+            retries += 1
+            try:
+                session = db.Session()
+                session.execute('''
+                  INSERT INTO `message_changelog` (`message_id`, `change_type`, `old`, `new`, `description`, `date`)
+                  VALUES (:message_id, :change_type, :old, :new, :description, NOW())
+                ''', dict(message_id=message_id, change_type=change_type, old=old, new=new, description=description))
+                session.commit()
+                session.close()
+            except Exception:
+                logger.exception('Failed inserting message into auditlog. (Try %s/%s)', retries, max_retries)
+                if retries < max_retries:
+                    sleep(.2)
+                    continue
+                else:
+                    raise Exception('Failed inserting message into auditlog retries exceeded')
+            else:
+                logger.info('Logged change information for message (ID %s)', message_id)
+                break

--- a/src/iris/sender/auditlog.py
+++ b/src/iris/sender/auditlog.py
@@ -23,7 +23,6 @@ def message_change(message_id, change_type, old, new, description):
         with db.guarded_session() as session:
             retries += 1
             try:
-                session = db.Session()
                 session.execute('''
                   INSERT INTO `message_changelog` (`message_id`, `change_type`, `old`, `new`, `description`, `date`)
                   VALUES (:message_id, :change_type, :old, :new, :description, NOW())

--- a/src/iris/sender/cache.py
+++ b/src/iris/sender/cache.py
@@ -58,6 +58,8 @@ class Cache():
                 del self.data[key]
             cursor.close()
             connection.close()
+        else:
+            self.data = {}
 
 
 class DynamicPlanMap(Cache):
@@ -434,10 +436,12 @@ def refresh():
 
 
 def purge():
+    targets.purge()
     target_names.purge()
     targets_for_role.purge()
     incidents.purge()
     dynamic_plan_map.purge()
+    plan_notifications.purge()
 
 
 def init(api_host, config):
@@ -472,9 +476,7 @@ def init(api_host, config):
                       'SELECT * FROM `incident` WHERE `id`=%s',
                       'SELECT `id` from `incident` WHERE `active`=True AND `id` IN %s')
     roles = Cache(db.engine, 'SELECT * FROM `target_role` WHERE `id`=%s', None)
-    # TODO: purge based on target acive column?
     targets = Cache(db.engine, 'SELECT * FROM `target` WHERE `id`=%s', None)
-    # TODO: also purge this cache?
     plan_notifications = Cache(db.engine,
                                'SELECT * FROM `plan_notification` WHERE `id`=%s',
                                ('SELECT `plan_notification`.`id` FROM `plan_notification` '


### PR DESCRIPTION
Because the targets cache is never purged if a team is renamed all plans that are now pointing to that new team name will fail because the targets cache will reflect the old name. 