### PR TITLE
Clean up sender logging,  set default aggregation window

### DIFF
--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -847,8 +847,7 @@ class AuthMiddleware(object):
                     logger.warning('Tried authenticating with nonexistent app: "%s"', app_name)
                     raise HTTPUnauthorized('Authentication failure', '', [])
                 if username_header and not app['allow_authenticating_users']:
-                    logger.warning('Unprivileged application %s tried authenticating %s',
-                                app['name'], username_header)
+                    logger.warning('Unprivileged application %s tried authenticating %s', app['name'], username_header)
                     raise HTTPUnauthorized('This application does not have the power to authenticate usernames', '', [])
                 window = int(time.time()) // 5
                 for api_key in (str(app['key']), str(app['secondary_key'])):
@@ -3007,9 +3006,7 @@ class Application(object):
                     # above, avoid the expected integrity error here by bailing
                     # early
                     if new_modes is not None and mode not in new_modes:
-                        logger.warning(('Not setting default priority %s to mode %s for app %s '
-                                     'as this mode was disabled as part of this app update'),
-                                    priority, mode, app_name)
+                        logger.warning(('Not setting default priority %s to mode %s for app %s as this mode was disabled as part of this app update'), priority, mode, app_name)
                         continue
 
                     try:

--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -786,7 +786,7 @@ class AuthMiddleware(object):
                 app, client_digest = req.get_header('AUTHORIZATION', '')[5:].split(':', 1)
 
             if app not in cache.applications:
-                logger.warn('Tried authenticating with nonexistent app: "%s"', app)
+                logger.warning('Tried authenticating with nonexistent app: "%s"', app)
                 raise HTTPUnauthorized('Authentication failure',
                                        'Application not found', [])
             req.context['app'] = cache.applications[app]
@@ -813,7 +813,7 @@ class AuthMiddleware(object):
             # determine if we're correctly using an application key
             api_key = req.get_param('key', required=True)
             if not equals(api_key, str(app['key'])) or equals(api_key, str(app['secondary_key'])):
-                logger.warn('Application key invalid')
+                logger.warning('Application key invalid')
                 raise HTTPUnauthorized('Authentication failure', '', [])
             return
 
@@ -844,10 +844,10 @@ class AuthMiddleware(object):
                 app_name, client_digest = auth[5:].split(':', 1)
                 app = cache.applications.get(app_name)
                 if not app:
-                    logger.warn('Tried authenticating with nonexistent app: "%s"', app_name)
+                    logger.warning('Tried authenticating with nonexistent app: "%s"', app_name)
                     raise HTTPUnauthorized('Authentication failure', '', [])
                 if username_header and not app['allow_authenticating_users']:
-                    logger.warn('Unprivileged application %s tried authenticating %s',
+                    logger.warning('Unprivileged application %s tried authenticating %s',
                                 app['name'], username_header)
                     raise HTTPUnauthorized('This application does not have the power to authenticate usernames', '', [])
                 window = int(time.time()) // 5
@@ -879,9 +879,9 @@ class AuthMiddleware(object):
                             return
                 # No successful HMACs match, fail auth.
                 if username_header:
-                    logger.warn('HMAC doesn\'t validate for app %s (passing username %s)', app['name'], username_header)
+                    logger.warning('HMAC doesn\'t validate for app %s (passing username %s)', app['name'], username_header)
                 else:
-                    logger.warn('HMAC doesn\'t validate for app %s; %s doesn\'t match "%s"', app['name'], client_digest, text)
+                    logger.warning('HMAC doesn\'t validate for app %s; %s doesn\'t match "%s"', app['name'], client_digest, text)
                 raise HTTPUnauthorized('Authentication failure', 'HMAC failed validation. Check API key/clock skew', [])
 
             except (ValueError, KeyError):
@@ -889,7 +889,7 @@ class AuthMiddleware(object):
                 raise HTTPUnauthorized('Authentication failure', '', [])
 
         else:
-            logger.warn('Request has malformed/missing HMAC authorization header')
+            logger.warning('Request has malformed/missing HMAC authorization header')
             raise HTTPUnauthorized('Authentication failure', 'Malformed/missing HMAC authorization header', [])
 
 
@@ -1612,7 +1612,7 @@ class Incidents(object):
             plan_id = session.execute('SELECT `plan_id` FROM `plan_active` WHERE `name` = :plan',
                                       {'plan': incident_params['plan']}).scalar()
             if not plan_id:
-                logger.warn('Plan "%s" not found.', incident_params['plan'])
+                logger.warning('Plan "%s" not found.', incident_params['plan'])
                 raise HTTPNotFound()
             num_dynamic = session.execute('SELECT COUNT(DISTINCT `dynamic_index`) FROM `plan_notification` '
                                           'WHERE `plan_id` = :plan_id',
@@ -3007,7 +3007,7 @@ class Application(object):
                     # above, avoid the expected integrity error here by bailing
                     # early
                     if new_modes is not None and mode not in new_modes:
-                        logger.warn(('Not setting default priority %s to mode %s for app %s '
+                        logger.warning(('Not setting default priority %s to mode %s for app %s '
                                      'as this mode was disabled as part of this app update'),
                                     priority, mode, app_name)
                         continue
@@ -3950,7 +3950,7 @@ class ResponseMixin(object):
             target_id = session.execute(sql, {'destination': dest}).scalar()
             if not target_id:
                 msg = 'Failed to lookup target from destination: %s' % dest
-                logger.warn(msg)
+                logger.warning(msg)
                 raise HTTPBadRequest('Invalid request', msg)
 
             sql = '''INSERT INTO `message` (`created`, `application_id`, `subject`, `target_id`,
@@ -4364,7 +4364,7 @@ class TwilioDeliveryUpdate(object):
             connection.close()
 
         if not affected:
-            logger.warn('No rows changed when updating delivery status for twilio sid: %s', sid)
+            logger.warning('No rows changed when updating delivery status for twilio sid: %s', sid)
 
         resp.status = HTTP_204
 

--- a/src/iris/bin/sender.py
+++ b/src/iris/bin/sender.py
@@ -610,6 +610,7 @@ def aggregate(now):
     for key in list(queues.keys()):
         aggregation_window = cache.plans[key[0]].get('aggregation_window')
         if aggregation_window is None:
+            logger.error('No aggregation window found for plan %s', key[0])
             aggregation_window = 0
         if now - sent.get(key, 0) >= aggregation_window:
             aggregated_message_ids = queues[key]

--- a/src/iris/bin/sender.py
+++ b/src/iris/bin/sender.py
@@ -1065,7 +1065,7 @@ def mark_message_as_sent(message):
 
     if len(message['body']) > MAX_MESSAGE_BODY_LENGTH:
         logger.warning('Message id %s has a ridiculously long body (%s chars). Truncating it.',
-                    message.get('message_id', '?'), len(message['body']))
+                       message.get('message_id', '?'), len(message['body']))
         message['body'] = message['body'][:MAX_MESSAGE_BODY_LENGTH]
 
     if 'aggregated_ids' in message:
@@ -1271,7 +1271,7 @@ def fetch_and_send_message(send_queue, vendor_manager):
         body_length = len(message['body'])
         if body_length > MAX_MESSAGE_BODY_LENGTH:
             logger.warning('Message id %s has a ridiculously long body (%s chars). Dropping it.',
-                        message['message_id'], body_length)
+                           message['message_id'], body_length)
             spawn(auditlog.message_change,
                   message['message_id'], auditlog.MODE_CHANGE, message.get('mode', '?'), 'drop',
                   'Dropping due to excessive body length (%s > %s chars)' % (

--- a/src/iris/bin/sender.py
+++ b/src/iris/bin/sender.py
@@ -382,7 +382,7 @@ def create_messages(msg_info):
                                             application_id, target_id, priority_id, body))
                             connection.commit()
                         except Exception:
-                            logger.exception('Failed inserting message for incident %s. (Try %s/%s)', incident_id, retries, max_retries)
+                            logger.warning('Failed inserting message for incident %s. (Try %s/%s)', incident_id, retries, max_retries)
                             if retries < max_retries:
                                 sleep(.2)
                                 continue
@@ -401,7 +401,7 @@ def create_messages(msg_info):
                 msg_count += 1
             else:
                 metrics.incr('target_not_found')
-                logger.warn('Failed to notify plan creator; no active target found: %s', name)
+                logger.warning('Failed to notify plan creator; no active target found: %s', name)
     if values_count > 0:
         retries = 0
         max_retries = 5
@@ -412,7 +412,7 @@ def create_messages(msg_info):
                 cursor.execute(msg_sql, query_params)
                 connection.commit()
             except Exception:
-                logger.exception('Failed inserting batch messages for incident %s. (Try %s/%s)', incident_id, retries, max_retries)
+                logger.warning('Failed inserting batch messages for incident %s. (Try %s/%s)', incident_id, retries, max_retries)
                 if retries < max_retries:
                     sleep(.2)
                     continue
@@ -447,9 +447,9 @@ def deactivate():
                 break
         except Exception:
             if i == max_retries:
-                logger.exception('Failed running deactivate query. (Try %s/%s)', i, max_retries)
+                logger.warning('Failed running deactivate query. (Try %s/%s)', i, max_retries)
             else:
-                logger.warn('Deadlocked running deactivate query. (Try %s/%s)', i, max_retries)
+                logger.warning('Deadlocked running deactivate query. (Try %s/%s)', i, max_retries)
             sleep(.2)
 
     cursor.close()
@@ -581,7 +581,7 @@ def escalate():
 
                 connection.commit()
             except Exception:
-                logger.exception('Failed updating incident %s. (Try %s/%s)', incident_id, retries, max_retries)
+                logger.warning('Failed updating incident %s. (Try %s/%s)', incident_id, retries, max_retries)
                 if retries < max_retries:
                     sleep(.2)
                     continue
@@ -608,7 +608,9 @@ def aggregate(now):
     cursor.close()
     connection.close()
     for key in list(queues.keys()):
-        aggregation_window = cache.plans[key[0]]['aggregation_window']
+        aggregation_window = cache.plans[key[0]].get('aggregation_window')
+        if aggregation_window is None:
+            aggregation_window = 0
         if now - sent.get(key, 0) >= aggregation_window:
             aggregated_message_ids = queues[key]
             active_message_ids = aggregated_message_ids & all_actives
@@ -932,7 +934,7 @@ def set_target_contact(message):
         if result:
             cache.target_reprioritization(message)
         else:
-            logger.warn('target does not have mode %r', message)
+            logger.warning('target does not have mode %r', message)
             result = set_target_fallback_mode(message)
         return result
     except (ValueError, TypeError):
@@ -1033,7 +1035,7 @@ def mark_message_as_sent(message):
     cursor = connection.cursor()
     if not message['subject']:
         message['subject'] = ''
-        logger.warn('Message id %s has blank subject', message.get('message_id', '?'))
+        logger.warning('Message id %s has blank subject', message.get('message_id', '?'))
 
     max_retries = 3
 
@@ -1044,13 +1046,13 @@ def mark_message_as_sent(message):
             connection.commit()
             break
         except DataError:
-            logger.exception('Failed updating message metadata status (message ID %s) (application %s)', message.get('message_id', '?'), message.get('application', '?'))
+            logger.warning('Failed updating message metadata status (message ID %s) (application %s)', message.get('message_id', '?'), message.get('application', '?'))
             break
         except Exception:
             if i == max_retries:
-                logger.exception('Failed running sent message update query. (Try %s/%s)', i, max_retries)
+                logger.warning('Failed running sent message update query. (Try %s/%s)', i, max_retries)
             else:
-                logger.warn('Failed running sent message update query. (Try %s/%s)', i, max_retries)
+                logger.warning('Failed running sent message update query. (Try %s/%s)', i, max_retries)
             sleep(.2)
 
     # Clean messages cache
@@ -1062,7 +1064,7 @@ def mark_message_as_sent(message):
         message['subject'] = message['subject'][:255]
 
     if len(message['body']) > MAX_MESSAGE_BODY_LENGTH:
-        logger.warn('Message id %s has a ridiculously long body (%s chars). Truncating it.',
+        logger.warning('Message id %s has a ridiculously long body (%s chars). Truncating it.',
                     message.get('message_id', '?'), len(message['body']))
         message['body'] = message['body'][:MAX_MESSAGE_BODY_LENGTH]
 
@@ -1080,13 +1082,13 @@ def mark_message_as_sent(message):
             connection.commit()
             break
         except DataError:
-            logger.exception('Failed updating message body+subject (message IDs %s) (application %s)', update_ids, message.get('application', '?'))
+            logger.warning('Failed updating message body+subject (message IDs %s) (application %s)', update_ids, message.get('application', '?'))
             break
         except Exception:
             if i == max_retries:
-                logger.exception('Failed updating message body+subject (message IDs %s) (application %s) (Try %s/%s)', update_ids, message.get('application', '?'), i, max_retries)
+                logger.warning('Failed updating message body+subject (message IDs %s) (application %s) (Try %s/%s)', update_ids, message.get('application', '?'), i, max_retries)
             else:
-                logger.warn('Failed updating message body+subject (message IDs %s) (application %s) (Try %s/%s)', update_ids, message.get('application', '?'), i, max_retries)
+                logger.warning('Failed updating message body+subject (message IDs %s) (application %s) (Try %s/%s)', update_ids, message.get('application', '?'), i, max_retries)
             sleep(.2)
 
     cursor.close()
@@ -1120,7 +1122,7 @@ def update_message_sent_status(message, status):
                             {'message_id': message_id, 'status': status})
             session.commit()
         except Exception:
-            logger.exception('Failed setting message sent status for message %s (Try %s/%s)', message_id, retries, max_retries)
+            logger.warning('Failed setting message sent status for message %s (Try %s/%s)', message_id, retries, max_retries)
             if retries < max_retries:
                 sleep(.2)
                 continue
@@ -1135,7 +1137,7 @@ def update_message_sent_status(message, status):
 def mark_message_has_no_contact(message):
     message_id = message.get('message_id')
     if not message_id:
-        logger.warn('Cannot mark message "%s" as not having contact as message_id is missing', message)
+        logger.warning('Cannot mark message "%s" as not having contact as message_id is missing', message)
         return
 
     connection = db.engine.raw_connection()
@@ -1150,7 +1152,7 @@ def mark_message_has_no_contact(message):
             connection.commit()
             cursor.close()
         except Exception:
-            logger.exception('Failed setting message %s as not having contact (Try %s/%s)', message_id, retries, max_retries)
+            logger.warning('Failed setting message %s as not having contact (Try %s/%s)', message_id, retries, max_retries)
             if retries < max_retries:
                 sleep(.2)
                 continue
@@ -1223,7 +1225,7 @@ def fetch_and_send_message(send_queue, vendor_manager):
 
     # If this app breaches hard quota, drop message on floor, and update in UI if it has an ID
     if not is_retry and not message_to_slave and not quota.allow_send(message):
-        logger.warn('Hard message quota exceeded; Dropping this message on floor: %s', message)
+        logger.warning('Hard message quota exceeded; Dropping this message on floor: %s', message)
         if message['message_id']:
             spawn(auditlog.message_change,
                   message['message_id'], auditlog.MODE_CHANGE, message.get('mode', '?'), 'drop',
@@ -1268,7 +1270,7 @@ def fetch_and_send_message(send_queue, vendor_manager):
         # body is too long and we were normally going to send it anyway.
         body_length = len(message['body'])
         if body_length > MAX_MESSAGE_BODY_LENGTH:
-            logger.warn('Message id %s has a ridiculously long body (%s chars). Dropping it.',
+            logger.warning('Message id %s has a ridiculously long body (%s chars). Dropping it.',
                         message['message_id'], body_length)
             spawn(auditlog.message_change,
                   message['message_id'], auditlog.MODE_CHANGE, message.get('mode', '?'), 'drop',
@@ -1293,7 +1295,7 @@ def fetch_and_send_message(send_queue, vendor_manager):
     try:
         success, sent_locally = distributed_send_message(message, vendor_manager)
     except Exception:
-        logger.exception('Failed to send message: %s', message)
+        logger.warning('Failed to send message: %s', message)
         add_mode_stat(message['mode'], None)
         if message.get('unexpanded'):
             logger.error('unable to send %(mode)s %(message_id)s %(application)s %(destination)s %(subject)s %(body)s', message)
@@ -1394,7 +1396,7 @@ def maintain_workers(config):
         try:
             email_smtp_workers = iris_smtp.iris_smtp.determine_worker_count(email_vendor)
         except Exception:
-            logger.exception('Failed determining MX records this round')
+            logger.warning('Failed determining MX records this round')
             email_smtp_workers = None
 
         old_email_worker_count = workers_per_mode.pop('email', None)
@@ -1532,7 +1534,7 @@ def prune_old_audit_logs_worker():
             connection.commit()
             cursor.close()
         except Exception:
-            logger.exception('Failed pruning old audit logs')
+            logger.warning('Failed pruning old audit logs')
         finally:
             connection.close()
 

--- a/src/iris/bin/sync_targets.py
+++ b/src/iris/bin/sync_targets.py
@@ -648,7 +648,7 @@ def sync_ldap_lists(ldap_settings, engine):
                     logger.info('Added %s to list %s', member, list_name)
                 except (IntegrityError, DataError):
                     metrics.incr('ldap_memberships_failed_to_add')
-                    logger.warn('Failed adding %s to %s', member, list_name)
+                    logger.warning('Failed adding %s to %s', member, list_name)
 
                 user_add_count += 1
                 if (ldap_add_pause_interval is not None) and (user_add_count % ldap_add_pause_interval) == 0:

--- a/src/iris/plugins/core.py
+++ b/src/iris/plugins/core.py
@@ -44,7 +44,7 @@ class IrisPlugin(object):
                         self.name, msg_id, digits)
             if digits not in self.phone_response_menu:
                 msg = 'Got unknown option from user: ' + digits
-                logger.warn(msg)
+                logger.warning(msg)
                 return msg
             cmd, args = self.phone_response_menu[digits]['cmd'], None
         else:

--- a/src/iris/role_lookup/mailing_list.py
+++ b/src/iris/role_lookup/mailing_list.py
@@ -40,7 +40,7 @@ class mailing_list(object):
 
         if self.max_list_names > 0 and list_count >= self.max_list_names:
             logger.warning('Not returning any results for list group %s as it contains too many members (%s > %s)',
-                        list_name, list_count, self.max_list_names)
+                           list_name, list_count, self.max_list_names)
             cursor.close()
             connection.close()
             return None

--- a/src/iris/role_lookup/mailing_list.py
+++ b/src/iris/role_lookup/mailing_list.py
@@ -31,7 +31,7 @@ class mailing_list(object):
         list_info = cursor.fetchone()
 
         if not list_info:
-            logger.warn('Invalid mailing list %s', list_name)
+            logger.warning('Invalid mailing list %s', list_name)
             cursor.close()
             connection.close()
             return None
@@ -39,7 +39,7 @@ class mailing_list(object):
         list_id, list_count = list_info
 
         if self.max_list_names > 0 and list_count >= self.max_list_names:
-            logger.warn('Not returning any results for list group %s as it contains too many members (%s > %s)',
+            logger.warning('Not returning any results for list group %s as it contains too many members (%s > %s)',
                         list_name, list_count, self.max_list_names)
             cursor.close()
             connection.close()

--- a/src/iris/sender/auditlog.py
+++ b/src/iris/sender/auditlog.py
@@ -13,7 +13,7 @@ SENT_CHANGE = 'sent-change'
 
 def message_change(message_id, change_type, old, new, description):
     if not message_id:
-        logger.warn('Not logging %s for message as it does not have an id', change_type)
+        logger.warning('Not logging %s for message as it does not have an id', change_type)
         return
 
     # retry to guard against deadlocks

--- a/src/iris/sender/rpc.py
+++ b/src/iris/sender/rpc.py
@@ -81,13 +81,13 @@ def handle_api_notification_request(socket, address, req):
     if not role and not target_list:
         reject_api_request(socket, address, 'INVALID role')
         logger.warning('Dropping OOB message with invalid role "%s" from app %s',
-                    role, notification['application'])
+                       role, notification['application'])
         return
     target = notification.get('target')
     if not (target or target_list):
         reject_api_request(socket, address, 'INVALID target')
         logger.warning('Dropping OOB message with invalid target "%s" from app %s',
-                    target, notification['application'])
+                       target, notification['application'])
         return
     expanded_targets = None
     # if role is literal_target skip unrolling
@@ -124,7 +124,7 @@ def handle_api_notification_request(socket, address, req):
         if not expanded_targets and not has_literal_target:
             reject_api_request(socket, address, 'INVALID role:target')
             logger.warning('Dropping OOB message with invalid role:target "%s:%s" from app %s',
-                        role, target, notification['application'])
+                           role, target, notification['application'])
             return
 
     sanitize_unicode_dict(notification)
@@ -134,7 +134,7 @@ def handle_api_notification_request(socket, address, req):
     if 'template' in notification:
         if 'context' not in notification:
             logger.warning('Dropping OOB message due to missing context from app %s',
-                        notification['application'])
+                           notification['application'])
             reject_api_request(socket, address, 'INVALID context')
             return
         else:
@@ -143,13 +143,13 @@ def handle_api_notification_request(socket, address, req):
     elif 'email_html' in notification:
         if not isinstance(notification['email_html'], str):
             logger.warning('Dropping OOB message with invalid email_html from app %s: %s',
-                        notification['application'], notification['email_html'])
+                           notification['application'], notification['email_html'])
             reject_api_request(socket, address, 'INVALID email_html')
             return
     elif 'body' not in notification:
         reject_api_request(socket, address, 'INVALID body')
         logger.warning('Dropping OOB message with invalid body from app %s',
-                    notification['application'])
+                       notification['application'])
         return
 
     access_logger.info('-> %s OK, to %s:%s (%s:%s)',

--- a/src/iris/sender/rpc.py
+++ b/src/iris/sender/rpc.py
@@ -72,7 +72,7 @@ def handle_api_notification_request(socket, address, req):
     notification = req['data']
     if 'application' not in notification:
         reject_api_request(socket, address, 'INVALID application')
-        logger.warn('Dropping OOB message due to missing application key')
+        logger.warning('Dropping OOB message due to missing application key')
         return
     notification['subject'] = '[%s] %s' % (notification['application'],
                                            notification.get('subject', ''))
@@ -80,13 +80,13 @@ def handle_api_notification_request(socket, address, req):
     role = notification.get('role')
     if not role and not target_list:
         reject_api_request(socket, address, 'INVALID role')
-        logger.warn('Dropping OOB message with invalid role "%s" from app %s',
+        logger.warning('Dropping OOB message with invalid role "%s" from app %s',
                     role, notification['application'])
         return
     target = notification.get('target')
     if not (target or target_list):
         reject_api_request(socket, address, 'INVALID target')
-        logger.warn('Dropping OOB message with invalid target "%s" from app %s',
+        logger.warning('Dropping OOB message with invalid target "%s" from app %s',
                     target, notification['application'])
         return
     expanded_targets = None
@@ -123,7 +123,7 @@ def handle_api_notification_request(socket, address, req):
                 expanded_targets = None
         if not expanded_targets and not has_literal_target:
             reject_api_request(socket, address, 'INVALID role:target')
-            logger.warn('Dropping OOB message with invalid role:target "%s:%s" from app %s',
+            logger.warning('Dropping OOB message with invalid role:target "%s:%s" from app %s',
                         role, target, notification['application'])
             return
 
@@ -133,7 +133,7 @@ def handle_api_notification_request(socket, address, req):
     # needed iris key.
     if 'template' in notification:
         if 'context' not in notification:
-            logger.warn('Dropping OOB message due to missing context from app %s',
+            logger.warning('Dropping OOB message due to missing context from app %s',
                         notification['application'])
             reject_api_request(socket, address, 'INVALID context')
             return
@@ -142,13 +142,13 @@ def handle_api_notification_request(socket, address, req):
             notification['context']['iris'] = {}
     elif 'email_html' in notification:
         if not isinstance(notification['email_html'], str):
-            logger.warn('Dropping OOB message with invalid email_html from app %s: %s',
+            logger.warning('Dropping OOB message with invalid email_html from app %s: %s',
                         notification['application'], notification['email_html'])
             reject_api_request(socket, address, 'INVALID email_html')
             return
     elif 'body' not in notification:
         reject_api_request(socket, address, 'INVALID body')
-        logger.warn('Dropping OOB message with invalid body from app %s',
+        logger.warning('Dropping OOB message with invalid body from app %s',
                     notification['application'])
         return
 

--- a/src/iris/ui/__init__.py
+++ b/src/iris/ui/__init__.py
@@ -315,7 +315,7 @@ class Login():
             raise HTTPFound('/login')
 
         if not auth.valid_username(username):
-            logger.warn('Tried to login with invalid username %s', username)
+            logger.warning('Tried to login with invalid username %s', username)
             if self.debug:
                 flash_message(req, 'Invalid username', 'danger')
             else:
@@ -326,7 +326,7 @@ class Login():
             logger.info('Successful login for %s', username)
             auth.login_user(req, username)
         else:
-            logger.warn('Failed login for %s', username)
+            logger.warning('Failed login for %s', username)
             flash_message(req, 'Invalid credentials', 'danger')
             raise HTTPFound('/login')
 

--- a/src/iris/ui/auth/ldap.py
+++ b/src/iris/ui/auth/ldap.py
@@ -55,7 +55,7 @@ class Authenticator:
         except ldap.INVALID_CREDENTIALS:
             return False
         except (ldap.SERVER_DOWN, ldap.INVALID_DN_SYNTAX) as err:
-            logger.warn("%s", err)
+            logger.warning("%s", err)
             return None
         return True
 

--- a/src/iris/vendors/iris_slack.py
+++ b/src/iris/vendors/iris_slack.py
@@ -114,7 +114,7 @@ class iris_slack(object):
                 # Slack rate limiting. Sleep for a few seconds (chosen randomly to spread load),
                 # then raise error to retry
                 sleep_time = random.randrange(1, self.sleep_range)
-                logger.warn('Hit slack rate limiting, sleeping for %s', sleep_time)
+                logger.warning('Hit slack rate limiting, sleeping for %s', sleep_time)
                 sleep(sleep_time)
                 response.raise_for_status()
             else:

--- a/src/iris/webhooks/alertmanager.py
+++ b/src/iris/webhooks/alertmanager.py
@@ -21,7 +21,7 @@ class alertmanager(object):
     def create_context(self, body):
         context_json_str = ujson.dumps(body)
         if len(context_json_str) > 65535:
-            logger.warn('POST to alertmanager exceeded acceptable size')
+            logger.warning('POST to alertmanager exceeded acceptable size')
             raise HTTPBadRequest('Context too long')
 
         return context_json_str
@@ -68,7 +68,7 @@ class alertmanager(object):
             ''', {'app_id': app['id'], 'plan_id': plan_id}).scalar()
 
             if not app_template_count:
-                logger.warn('no plan template exists for this app')
+                logger.warning('no plan template exists for this app')
                 raise HTTPBadRequest('No plan template actions exist for this app')
 
             data = {

--- a/src/iris/webhooks/grafana.py
+++ b/src/iris/webhooks/grafana.py
@@ -13,13 +13,13 @@ class grafana(object):
 
     def validate_post(self, body):
         if not all(k in body for k in("ruleName", "state")):
-            logger.warn('missing ruleName and/or state attributes')
+            logger.warning('missing ruleName and/or state attributes')
             raise HTTPBadRequest('missing ruleName and/of state attributes')
 
     def create_context(self, body):
         context_json_str = ujson.dumps(body)
         if len(context_json_str) > 65535:
-            logger.warn('POST to grafana exceeded acceptable size')
+            logger.warning('POST to grafana exceeded acceptable size')
             raise HTTPBadRequest('Context too long')
 
         return context_json_str
@@ -41,7 +41,7 @@ class grafana(object):
             plan_id = session.execute('SELECT `plan_id` FROM `plan_active` WHERE `name` = :plan',
                                       {'plan': plan}).scalar()
             if not plan_id:
-                logger.warn('No active plan "%s" found', plan)
+                logger.warning('No active plan "%s" found', plan)
                 raise HTTPInvalidParam('plan does not exist or is not active')
 
             app = req.context['app']
@@ -60,7 +60,7 @@ class grafana(object):
             ''', {'app_id': app['id'], 'plan_id': plan_id}).scalar()
 
             if not app_template_count:
-                logger.warn('no plan template exists for this app')
+                logger.warning('no plan template exists for this app')
                 raise HTTPBadRequest('No plan template actions exist for this app')
 
             data = {


### PR DESCRIPTION
- Don't log the tracebacks for the deadlock retries so the logs are easier to read
- Add a default value to aggregation window
- Change deprecated logger.warn() methods to logger.warning