### PR TITLE
Add restricted country sms override

### DIFF
--- a/configs/config.dev.yaml
+++ b/configs/config.dev.yaml
@@ -41,6 +41,8 @@ supported_timezones:
   - 'Asia/Shanghai'
   - 'UTC'
 
+sms_override_template: "ALERT: Incident %s has been triggered by Iris! Please check Iris for more information. - SMS template override"
+
 healthcheck_path: /tmp/status
 
 allowed_origins:

--- a/db/schema_0.sql
+++ b/db/schema_0.sql
@@ -816,6 +816,15 @@ CREATE TABLE `notification_category` (
   UNIQUE KEY (`application_id`, `name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
+DROP TABLE IF EXISTS `mode_template_override`;
+CREATE TABLE `mode_template_override` (
+  `target_id` BIGINT(20) NOT NULL,
+  `mode_id` INT(11) NOT NULL,
+  PRIMARY KEY (`target_id`),
+  CONSTRAINT `target_id_override_ibfk_1` FOREIGN KEY (`target_id`) REFERENCES `target` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `mode_id_override_ibfk_1`  FOREIGN KEY (`mode_id`) REFERENCES `mode` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
 DROP TABLE IF EXISTS `category_override`;
 CREATE TABLE `category_override` (
   `user_id` BIGINT(20) NOT NULL,

--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -3788,9 +3788,7 @@ class User(object):
                              JOIN `mode` ON `mode`.`id` = `mode_template_override`.`mode_id`
                          WHERE `mode_template_override`.`target_id` = %s'''
         cursor.execute(mode_template_override_query, user_id)
-        user_data['template_overrides'] = []
-        for row in cursor:
-            user_data['template_overrides'].append(row['mode'])
+        user_data['template_overrides'] = [row['mode'] for row in cursor]
 
         # Get user contact modes
         modes_query = '''SELECT `priority`.`name` AS priority, `mode`.`name` AS `mode`

--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -3933,7 +3933,7 @@ class UserTemplateOverrides(object):
         except ValueError:
             raise HTTPBadRequest('Invalid json in post body')
         if not isinstance(data.get('template_overrides'), dict):
-            raise HTTPBadRequest('Invalid json in post body')
+            raise HTTPBadRequest('Invalid json in post body: template_overrides parameter is not a dict')
 
         # currently only sms is needed/supported
         override_val = data.get('template_overrides', {}).get('sms')
@@ -3959,7 +3959,7 @@ class UserTemplateOverrides(object):
         else:
             cursor.close()
             connection.close()
-            raise HTTPBadRequest('Invalid sms override setting value')
+            raise HTTPBadRequest(f'Invalid sms override setting value: {override_val}')
 
         cursor.close()
         connection.close()

--- a/src/iris/sender/auditlog.py
+++ b/src/iris/sender/auditlog.py
@@ -9,6 +9,7 @@ logger = logging.getLogger(__name__)
 MODE_CHANGE = 'mode-change'
 TARGET_CHANGE = 'target-change'
 SENT_CHANGE = 'sent-change'
+CONTENT_CHANGE = 'content-change'
 
 
 def message_change(message_id, change_type, old, new, description):

--- a/src/iris/ui/static/css/iris.css
+++ b/src/iris/ui/static/css/iris.css
@@ -1418,7 +1418,7 @@ table.dataTable thead .sorting_asc {
  */
 
 .user-settings .user-module {
-    min-height: 700px;
+    min-height: 850px;
 }
 
 .user-settings-name {
@@ -1450,6 +1450,10 @@ table.dataTable thead .sorting_asc {
 
 .user-settings-contact ul a:hover {
     text-decoration: underline;
+}
+
+.user-settings-overrides {
+    padding-top: 20px;
 }
 
 .user-settings table {
@@ -1503,6 +1507,14 @@ table.dataTable thead .sorting_asc {
 }
 
 #add-application-select {
+    width: auto;
+}
+
+#timezone-select {
+    width: auto;
+}
+
+#sms-override-select {
     width: auto;
 }
 
@@ -1919,8 +1931,4 @@ span.twitter-typeahead {
 
 .input-group.input-group-sm span.twitter-typeahead .tt-dropdown-menu {
     top: 28px !important;
-}
-
-#timezone-select {
-    width: auto;
 }

--- a/src/iris/ui/templates/user.html
+++ b/src/iris/ui/templates/user.html
@@ -68,6 +68,17 @@
             <select id="timezone-select" class="form-control border-bottom"></select>
             <button type="button" id="timezone-save" class="btn btn-primary btn-sm">Save</button>
         </div>
+
+        <div class="user-settings-overrides">
+            <h4>Restricted country SMS override</h4>
+            <span class="light">Enable this setting if you are receiving SMS in a country with special restrictions.</span>
+            <span class="light">This setting replaces SMS templates with a special carrier whitelisted template.</span>
+            <div id="sms-override-controls">
+                <select id="sms-override-select" class="form-control border-bottom"></select>
+                <button type="button" id="sms-override-save" class="btn btn-primary btn-sm">Save</button>
+            </div>
+        </div>
+
     </div>
 </div>
 <div id="reprioritization" class="module">

--- a/test/e2etest.py
+++ b/test/e2etest.py
@@ -2146,7 +2146,7 @@ def test_get_user(sample_user, sample_email, sample_admin_user):
     re = requests.get(base_url + 'users/' + sample_user, headers=username_header(sample_user))
     assert re.status_code == 200
     data = re.json()
-    assert data.keys() == {'teams', 'modes', 'per_app_modes', 'admin', 'contacts', 'name'}
+    assert data.keys() == {'teams', 'modes', 'per_app_modes', 'admin', 'contacts', 'name', 'template_overrides'}
     assert data['contacts']['email'] == sample_email
     assert data['name'] == sample_user
 
@@ -3221,6 +3221,35 @@ def test_user_update_timezone(sample_user):
     re = session.get(base_url + 'users/settings/' + sample_user)
     assert re.status_code == 200
     assert re.json()['timezone'] == timezones[1]
+
+
+def test_user_update_sms_override(sample_user):
+
+    session = requests.Session()
+    session.headers = username_header(sample_user)
+
+    # Change it to enabled and see if it sticks
+    re = session.post(base_url + 'users/overrides/' + sample_user,
+                      json={'template_overrides': {'sms': 'enabled'}})
+    assert re.status_code == 204
+
+    re = session.get(base_url + 'users/' + sample_user)
+    assert re.status_code == 200
+    assert 'sms' in re.json()['template_overrides']
+
+    # Change it to disabled and see if it sticks
+    re = session.post(base_url + 'users/overrides/' + sample_user,
+                      json={'template_overrides': {'sms': 'disabled'}})
+    assert re.status_code == 204
+
+    re = session.get(base_url + 'users/' + sample_user)
+    assert re.status_code == 200
+    assert 'sms' not in re.json()['template_overrides']
+
+    # test bad request
+    re = session.post(base_url + 'users/overrides/' + sample_user,
+                      json={'template_overrides': {'invalid_mode': 'disabled'}})
+    assert re.status_code == 400
 
 
 def test_comment(sample_user, sample_team, sample_application_name, sample_template_name):


### PR DESCRIPTION
To ensure successful SMS delivery in countries with restrictions like India messages must adhere to a pre-registered template. This PR allows users to override SMS bodies with the whitelisted template to prevent carriers from dropping their messages.