### PR TITLE
only log incident tracebacks when retries breached

### DIFF
--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -1717,7 +1717,7 @@ class Incidents(object):
 
                     session.commit()
                     session.close()
-                except Exception as e:
+                except (InternalError, OperationalError) as e:
                     logger.error('Failed inserting incident for plan %s. (Try %s/%s)', plan_id, retries, max_retries)
                     if retries < max_retries:
                         sleep_jitter = random.randint(10, 30) / 100

--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -1717,8 +1717,8 @@ class Incidents(object):
 
                     session.commit()
                     session.close()
-                except (InternalError, OperationalError) as e:
-                    logger.error('Failed inserting incident. (Try %s/%s)', retries, max_retries)
+                except Exception as e:
+                    logger.error('Failed inserting incident for plan %s. (Try %s/%s)', plan_id, retries, max_retries)
                     if retries < max_retries:
                         sleep_jitter = random.randint(10, 30) / 100
                         sleep(sleep_jitter)

--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -1718,13 +1718,13 @@ class Incidents(object):
                     session.commit()
                     session.close()
                 except (InternalError, OperationalError) as e:
-                    logger.exception('Failed inserting incident. (Try %s/%s)', retries, max_retries)
+                    logger.error('Failed inserting incident. (Try %s/%s)', retries, max_retries)
                     if retries < max_retries:
                         sleep_jitter = random.randint(10, 30) / 100
                         sleep(sleep_jitter)
                         continue
                     else:
-                        logger.error('Breached incident insertion retry quota. Bailing on incident for plan %s', plan_id)
+                        logger.exception('Breached incident insertion retry quota. Bailing on incident for plan %s', plan_id)
                         raise HTTPInternalServerError('Failed creating incident')
                 else:
                     break


### PR DESCRIPTION
For incident insertion sqlalchey InternalErrors and OperationalErrors only log the stack trace if retries are breached. otherwise,  simply log an error. 