### PR TITLE
datatable search and bugfixes

### DIFF
--- a/src/iris/bin/sync_targets.py
+++ b/src/iris/bin/sync_targets.py
@@ -414,7 +414,16 @@ def get_ldap_lists(l, search_strings, parent_list=None):
                              serverctrls=[req_ctrl],
                              attrlist=(search_strings['list_cn_field'], search_strings['list_name_field']),
                              filterstr=filterstr)
-        rtype, rdata, rmsgid, serverctrls = l.result3(msgid, timeout=ldap_timeout, resp_ctrl_classes=known_ldap_resp_ctrls)
+
+        retries = 0
+        while retries < 5:
+            try:
+                rtype, rdata, rmsgid, serverctrls = l.result3(msgid, timeout=ldap_timeout, resp_ctrl_classes=known_ldap_resp_ctrls)
+            except Exception:
+                logger.exception('Error getting ldap list memberships')
+                retries += 1
+            else:
+                break
 
         for (dn, data) in rdata:
             cn_field = data[search_strings['list_cn_field']][0]
@@ -454,7 +463,15 @@ def get_ldap_list_membership(l, search_strings, list_name):
                              attrlist=[search_strings['user_mail_field']],
                              filterstr=search_strings['user_membership_filter'] % escape_filter_chars(list_name)
                              )
-        rtype, rdata, rmsgid, serverctrls = l.result3(msgid, timeout=ldap_timeout, resp_ctrl_classes=known_ldap_resp_ctrls)
+        retries = 0
+        while retries < 5:
+            try:
+                rtype, rdata, rmsgid, serverctrls = l.result3(msgid, timeout=ldap_timeout, resp_ctrl_classes=known_ldap_resp_ctrls)
+            except Exception:
+                logger.exception('Error getting ldap list memberships')
+                retries += 1
+            else:
+                break
 
         for data in rdata:
             member = data[1].get(search_strings['user_mail_field'], [None])[0]

--- a/src/iris/sender/auditlog.py
+++ b/src/iris/sender/auditlog.py
@@ -17,6 +17,10 @@ def message_change(message_id, change_type, old, new, description):
         logger.warning('Not logging %s for message as it does not have an id', change_type)
         return
 
+    old = old[0:250]
+    new = new[0:250]
+    description = description[0:250]
+
     # retry to guard against deadlocks
     retries = 0
     max_retries = 5

--- a/src/iris/ui/static/css/iris.css
+++ b/src/iris/ui/static/css/iris.css
@@ -286,14 +286,10 @@ table.dataTable.display tr td:first-child {
     background-position: calc(100% - 5px) 13px;
 }
 
-.dataTables_filter {
-    display: none;
+#incidents-table_filter {
+    padding-right:  30px;
+    display: inline;
 }
-
-#applications-table_filter {
-    display: unset;
-}
-
 .dataTable tbody tr {
     cursor: pointer;
 }


### PR DESCRIPTION
- fix bug where default modes that are not supported by application could still be submitted
- fix bug where message change description could be too long causing SQL errors
- require at least one supported mode for applications
- add DataTable search for plans, incidents, templates, and applications
- add the ability to search by context summary in incidents page
- retries for ldap calls in target sync
