### PR TITLE
add configurable pauses between insert,update,delete transactions in sync_targets

### DIFF
--- a/configs/config.dev.yaml
+++ b/configs/config.dev.yaml
@@ -198,6 +198,8 @@ gmail_one_click_url_endpoint: 'http://localhost:16648/api/v0/gmail-oneclick/rela
 sync_script_nap_time: 3600 # wait time before syncing again
 # sync_script_ldap_timeout: 60
 # sync_script_ldap_pagination_size: 400
+## add short pauses in seconds between inserting, updating, and deleting rows to allow take pressure off databasee replication
+# target_update_pause: 0.1
 ## use this for LDAP settings for sync script lookup
 # init_config_hook: iris_internal.api.init_config
 

--- a/src/iris/bin/retention.py
+++ b/src/iris/bin/retention.py
@@ -433,7 +433,7 @@ def main():
         logger.error('Max days needs to at least be 1')
         return
 
-    cooldown_time = int(retention_settings['cooldown_time'])
+    cooldown_time = float(retention_settings['cooldown_time'])
     batch_size = int(retention_settings['batch_size'])
     run_interval = int(retention_settings['run_interval'])
     archive_path = retention_settings['archive_path']


### PR DESCRIPTION
- add configurable pauses between insert,update,delete transactions in sync_targets
- allow for sub-second intervals between message archiving batches to allow for smaller more frequent batches