### PR TITLE
target_sync improvements

### DIFF
--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -4041,18 +4041,8 @@ class ResponseMixin(object):
                 'body': body,
                 'destination': dest
             }
-            retries = 0
-            while retries < 3:
-                try:
-                    message_id = session.execute(sql, data).lastrowid
-                    session.commit()
-                except Exception as e:
-                    retries += 1
-                    if retries == 3:
-                        logger.exception("failed to create email message")
-                    sleep(0.2)
-                else:
-                    break
+            message_id = session.execute(sql, data).lastrowid
+            session.commit()
 
             session.close()
             return True, message_id

--- a/src/iris/bin/sync_targets.py
+++ b/src/iris/bin/sync_targets.py
@@ -391,7 +391,7 @@ def sync_from_oncall(config, engine, purge_old_users=True):
             except SQLAlchemyError as e:
                 logger.exception('Error inserting oncall_team %s: %s', t, e)
                 continue
-        session.commit()
+    session.commit()
     session.close()
 
     # mark users/teams inactive


### PR DESCRIPTION
- target_sync bug fixes
- remove batch message insert
- commit user's new mailing list memberships individually instead of all together 

Using a synchronously replicated database like Galera it is best to avoid large transactions as they impact replication performance. Due to this, it is actually faster and less prone to failures to split batched transactions up especially when write loads are high like with Iris.