### PR TITLE
fix case sensitive/insensitive ldap list name bug

### DIFF
--- a/src/iris/sender/quota.py
+++ b/src/iris/sender/quota.py
@@ -248,8 +248,6 @@ class ApplicationQuota(object):
 
         now = time()
         if last_notification_time is not None and (now - last_notification_time) < soft_quota_notification_interval:
-            logger.warning('Application %s breached soft quota. Will NOT notify %s:%s as they will only get a notification once every %s seconds.',
-                           application, target_role, target_name, soft_quota_notification_interval)
             return
 
         self.last_soft_quota_notification_time[application] = now


### PR DESCRIPTION
Because python name comparison is case sensitive but mysql is case insensitive a change in ldap list name where only the case changes will cause the sync script to mark the old ist inactive but adding the new list name will fail because the new name is not a unique key from mysql perspective.

To fix do case insensitive comparisons for removing lists and rename lists if only the case changed.