### PR TITLE
remove unecessary foreign keys from incidents/msgs

### DIFF
--- a/db/schema_0.sql
+++ b/db/schema_0.sql
@@ -65,10 +65,7 @@ CREATE TABLE `incident` (
   KEY `ix_incident_owner_id` (`owner_id`),
   KEY `ix_incident_active` (`active`),
   KEY `ix_incident_application_id` (`application_id`),
-  KEY `ix_incident_created` (`created`),
-  CONSTRAINT `incident_ibfk_1` FOREIGN KEY (`plan_id`) REFERENCES `plan` (`id`),
-  CONSTRAINT `incident_ibfk_2` FOREIGN KEY (`owner_id`) REFERENCES `user` (`target_id`),
-  CONSTRAINT `incident_ibfk_3` FOREIGN KEY (`application_id`) REFERENCES `application` (`id`)
+  KEY `ix_incident_created` (`created`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -108,15 +105,7 @@ CREATE TABLE `message` (
   KEY `ix_message_target_id` (`target_id`),
   KEY `ix_message_mode_id` (`mode_id`),
   KEY `ix_message_active` (`active`),
-  KEY `message_ibfk_8` (`template_id`),
-  CONSTRAINT `message_ibfk_1` FOREIGN KEY (`application_id`) REFERENCES `application` (`id`),
-  CONSTRAINT `message_ibfk_2` FOREIGN KEY (`target_id`) REFERENCES `target` (`id`),
-  CONSTRAINT `message_ibfk_3` FOREIGN KEY (`mode_id`) REFERENCES `mode` (`id`),
-  CONSTRAINT `message_ibfk_4` FOREIGN KEY (`plan_id`) REFERENCES `plan` (`id`),
-  CONSTRAINT `message_ibfk_5` FOREIGN KEY (`priority_id`) REFERENCES `priority` (`id`),
-  CONSTRAINT `message_ibfk_6` FOREIGN KEY (`incident_id`) REFERENCES `incident` (`id`),
-  CONSTRAINT `message_ibfk_7` FOREIGN KEY (`plan_notification_id`) REFERENCES `plan_notification` (`id`),
-  CONSTRAINT `message_ibfk_8` FOREIGN KEY (`template_id`) REFERENCES `template` (`id`)
+  KEY `message_ibfk_8` (`template_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 

--- a/src/iris/webhooks/alertmanager.py
+++ b/src/iris/webhooks/alertmanager.py
@@ -54,6 +54,9 @@ class alertmanager(object):
 
             app = req.context['app']
 
+            if not session.execute('SELECT EXISTS(SELECT 1 FROM `application` WHERE id = :id)', {'id': app['id']}).scalar():
+                raise HTTPBadRequest('Invalid application')
+
             context_json_str = self.create_context(alert_params)
 
             app_template_count = session.execute('''

--- a/src/iris/webhooks/grafana.py
+++ b/src/iris/webhooks/grafana.py
@@ -46,6 +46,9 @@ class grafana(object):
 
             app = req.context['app']
 
+            if not session.execute('SELECT EXISTS(SELECT 1 FROM `application` WHERE id = :id)', {'id': app['id']}).scalar():
+                raise HTTPBadRequest('Invalid application')
+
             context_json_str = self.create_context(alert_params)
 
             app_template_count = session.execute('''


### PR DESCRIPTION
 Foreign keys for incident and message tables are not necessary and incur a big performance cost at scale. Remove them and add integrity checks where necessary.