### PR TITLE
Add enpoint to get user's slack id

### DIFF
--- a/configs/config.dev.yaml
+++ b/configs/config.dev.yaml
@@ -176,7 +176,7 @@ vendors: []
 #- type: iris_slack
 #  name: slack
 #  auth_token: ''
-#  base_url: 'https://slack.com/api/chat.postMessage'
+#  base_url: 'https://slack.com/api'
 #  iris_incident_url: ''
 #  proxy: *proxy_shared
 #  message_attachments:

--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -5052,7 +5052,7 @@ class UserToSlackID(object):
         try:
             slack_id = slack_vendor.lookup_by_email(user_email['destination'])
         except Exception as e:
-            raise HTTPInternalServerError()
+            raise HTTPInternalServerError(description=e)
         if slack_id:
             cache.add_slack_id(username, slack_id)
             resp.status = HTTP_201

--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -4987,6 +4987,7 @@ class NotificationCategories(object):
             cursor.close()
             conn.close()
 
+
 class UserToSlackID(object):
     allow_read_no_auth = True
 
@@ -5043,9 +5044,10 @@ class UserToSlackID(object):
         slack_id = slack_vendor.lookup_by_email(user_email['destination'])
         if slack_id:
             resp.status = HTTP_201
-            resp.body = ujson.dumps({'slack_id':slack_id})
+            resp.body = ujson.dumps({'slack_id': slack_id})
         else:
             raise HTTPNotFound('could not find a slack id for this user')
+
 
 class CategoryOverrides(object):
     enforce_user = True

--- a/src/iris/cache.py
+++ b/src/iris/cache.py
@@ -92,10 +92,12 @@ def cache_modes():
     cursor.close()
     connection.close()
 
+
 def add_slack_id(username, slack_id):
     global slack_ids
     # slack ids shouldn't change so we don't have to worry about refreshing them
     slack_ids[username] = slack_id
+
 
 def init():
     cache_applications()

--- a/src/iris/cache.py
+++ b/src/iris/cache.py
@@ -11,6 +11,7 @@ priorities = {}    # name -> dict of info
 target_types = {}  # name -> id
 target_roles = {}  # name -> id
 modes = {}         # name -> id
+slack_ids = {}     # name -> id
 
 
 def cache_applications():
@@ -91,6 +92,10 @@ def cache_modes():
     cursor.close()
     connection.close()
 
+def add_slack_id(username, slack_id):
+    global slack_ids
+    # slack ids shouldn't change so we don't have to worry about refreshing them
+    slack_ids[username] = slack_id
 
 def init():
     cache_applications()

--- a/src/iris/vendors/iris_slack.py
+++ b/src/iris/vendors/iris_slack.py
@@ -32,7 +32,7 @@ class iris_slack(object):
         self.sleep_range = config.get('sleep_range', 4)
         self.message_attachments = self.config.get('message_attachments', {})
 
-    def lookup_by_email(self,email):
+    def lookup_by_email(self, email):
         lookup_endpoint = self.config['base_url'] + "/users.lookupByEmail"
         payload = {'token': self.config['auth_token'], 'email': email}
         try:

--- a/src/iris/vendors/iris_slack.py
+++ b/src/iris/vendors/iris_slack.py
@@ -32,6 +32,26 @@ class iris_slack(object):
         self.sleep_range = config.get('sleep_range', 4)
         self.message_attachments = self.config.get('message_attachments', {})
 
+    def lookup_by_email(self,email):
+        lookup_endpoint = self.config['base_url'] + "/users.lookupByEmail"
+        payload = {'token': self.config['auth_token'], 'email': email}
+        try:
+            response = requests.post(lookup_endpoint,
+                                     data=payload,
+                                     proxies=self.proxy,
+                                     timeout=self.timeout)
+            if response.status_code == 200:
+                data = response.json()
+                if data.get('ok') and data.get('user'):
+                    if data['user'].get('id'):
+                        return data['user']['id']
+
+            logger.error('Failed resolve user id from email: %d', response.status_code)
+            return False
+        except Exception:
+            logger.exception('Slack post request failed')
+            raise
+
     def construct_attachments(self, message):
         # TODO: Verify title, title_link and text.
         att_json = {
@@ -90,8 +110,9 @@ class iris_slack(object):
     def send_message(self, message):
         start = time.time()
         payload = self.get_message_payload(message)
+        message_endpoint = self.config['base_url'] + "/chat.postMessage"
         try:
-            response = requests.post(self.config['base_url'],
+            response = requests.post(message_endpoint,
                                      data=payload,
                                      proxies=self.proxy,
                                      timeout=self.timeout)


### PR DESCRIPTION
In order to tag a user in a slack message created via an api request, it is necessary to use their slack id. This endpoint will allow clients to resolve that slack id from a username so it can be incorporated in the body of an iris message.