### PR TITLE
Add a configurable default per app quota for message creation

### DIFF
--- a/configs/config.dev.yaml
+++ b/configs/config.dev.yaml
@@ -135,6 +135,25 @@ sender:
   ## slaves to be cycled through
   is_master: True
 
+  # default_rate_def:
+  #   # hard quota 60 messages in a period, soft quota 30 messages in a period, 1 minute HQ period length, 1 minute SQ period length, no plans/targets
+  #   #self.default_rate_def = (40,30,1,1,3600,None,None)
+  #   # how many messages in a period before they are dropped
+  #   hard_limit: 30
+  #   # how many messages in a period before notification is sent out
+  #   soft_limit: 20
+  #   # period length for hard limit
+  #   hard_duration: 1
+  #   # period length for soft limit
+  #   soft_duration: 1
+  #   # time to wait before messages can be created again
+  #   wait_time: 3600
+  #   # target that will receive notification for soft quota breaches
+  #   target_name: foo_team
+  #   target_role: team
+  #   # plan for incident that will be raised if there is a hard quota breach
+  #   plan_name: bar_plan
+
 #slaves:
 #  - host: 127.0.0.1
 #    port: 2322

--- a/configs/config.dev.yaml
+++ b/configs/config.dev.yaml
@@ -136,8 +136,6 @@ sender:
   is_master: True
 
   # default_rate_def:
-  #   # hard quota 60 messages in a period, soft quota 30 messages in a period, 1 minute HQ period length, 1 minute SQ period length, no plans/targets
-  #   #self.default_rate_def = (40,30,1,1,3600,None,None)
   #   # how many messages in a period before they are dropped
   #   hard_limit: 30
   #   # how many messages in a period before notification is sent out

--- a/src/iris/bin/sender.py
+++ b/src/iris/bin/sender.py
@@ -1695,7 +1695,7 @@ def init_sender(config):
         }]
 
     global quota
-    quota = ApplicationQuota(db, cache.targets_for_role, message_send_enqueue, config['sender'].get('sender_app'))
+    quota = ApplicationQuota(db, cache.targets_for_role, message_send_enqueue, config['sender'].get('sender_app'), config['sender'].get('default_rate_def', {}))
 
     global coordinator
     zk_hosts = config['sender'].get('zookeeper_cluster', False)

--- a/src/iris/sender/quota.py
+++ b/src/iris/sender/quota.py
@@ -8,7 +8,6 @@ from collections import deque
 from datetime import datetime
 import iris.cache
 from iris import metrics
-from iris.api import load_config
 import logging
 import ujson
 
@@ -60,19 +59,17 @@ soft_quota_notification_interval = 1800
 
 class ApplicationQuota(object):
 
-    def __init__(self, db, expand_targets, message_send_enqueue, sender_app):
+    def __init__(self, db, expand_targets, message_send_enqueue, sender_app, rate_configs):
         self.db = db
-        config = load_config()
-
         # configure default rate limiting params for messages
-        hard_limit = config['sender'].get('default_rate_def', {}).get('hard_limit', 600)
-        soft_limit = config['sender'].get('default_rate_def', {}).get('soft_limit', 60)
-        hard_duration = config['sender'].get('default_rate_def', {}).get('hard_duration', 1)
-        soft_duration = config['sender'].get('default_rate_def', {}).get('soft_duration', 1)
-        wait_time = config['sender'].get('default_rate_def', {}).get('wait_time', 3600)
-        plan_name = config['sender'].get('default_rate_def', {}).get('plan_name', None)
-        target_name = config['sender'].get('default_rate_def', {}).get('target_name', None)
-        target_role = config['sender'].get('default_rate_def', {}).get('target_role', None)
+        hard_limit = rate_configs.get('hard_limit', 6000)
+        soft_limit = rate_configs.get('soft_limit', 600)
+        hard_duration = rate_configs.get('hard_duration', 1)
+        soft_duration = rate_configs.get('soft_duration', 1)
+        wait_time = rate_configs.get('wait_time', 3600)
+        plan_name = rate_configs.get('plan_name', None)
+        target_name = rate_configs.get('target_name', None)
+        target_role = rate_configs.get('target_role', None)
         target = None
         if target_name and target_role:
             target = (target_name, target_role)

--- a/test/test_sender.py
+++ b/test/test_sender.py
@@ -348,7 +348,7 @@ def test_quotas(mocker):
                  )])
     mocker.patch('iris.sender.quota.ApplicationQuota.notify_incident')
     mocker.patch('iris.sender.quota.ApplicationQuota.notify_target')
-    quotas = ApplicationQuota(None, None, None, None)
+    quotas = ApplicationQuota(None, None, None, None, {})
     sleep(1)
 
     # ensure drop messages don't count


### PR DESCRIPTION
previously the default behaviour was no message creation quotas unless a user specified one on the application page. Now there is a configurable default quota that will apply to all application without a defined quota. If a quota is specified in the application page that will supersede the default quota settings. 