### PR TITLE
add internal only application endpoint

### DIFF
--- a/configs/config.dev.yaml
+++ b/configs/config.dev.yaml
@@ -97,7 +97,12 @@ webhooks:
   - alertmanager
 
 ## custom incident handler can be created to do additional tasks after incident creation
-#custom_incident_handler_module: iris.custom_incident_handler
+# custom_incident_handler_module: iris.custom_incident_handler
+
+## allows listed applications to access internal API endpoints that return sensitive data including application API keys
+## this should only be used by applications that are essentially extensions of iris itself like a custom sender
+# allowlisted_internal_apps:
+#   - iris-internal-application
 
 #####################
 ### Iris-sender

--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -5407,7 +5407,7 @@ class CategoryOverrides(object):
         resp.status = HTTP_204
 
 
-class InternalApplicationsAuth(object):
+class InternalApplicationsAuth():
     allow_read_no_auth = False
 
     def __init__(self, config):

--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -5388,60 +5388,6 @@ class CategoryOverrides(object):
         resp.status = HTTP_204
 
 
-class InternalApplications(object):
-    allow_read_no_auth = False
-
-    def __init__(self, config):
-        self.allowlisted_apps = config.get('allowlisted_internal_apps', [])
-
-    def on_get(self, req, resp, app_name):
-        if req.context['app']['name'] not in self.allowlisted_apps:
-            raise HTTPUnauthorized('Authentication failure', 'this endpoint is only available for internal use by allowlisted apps', [])
-
-        connection = db.engine.raw_connection()
-        cursor = connection.cursor(db.dict_cursor)
-        app_query = '''SELECT
-            `id`, `name`, `context_template`, `sample_context`, `summary_template`, `mobile_template`
-            FROM `application`
-            WHERE `auth_only` is False AND `application`.`name` = %s'''
-        cursor.execute(app_query, app_name)
-        app = cursor.fetchone()
-        if not app:
-            cursor.close()
-            connection.close()
-            raise HTTPBadRequest('Application %s not found' % app_name)
-
-        cursor.execute(get_vars_query, app['id'])
-        app['variables'] = []
-        app['required_variables'] = []
-        app['title_variable'] = None
-        for row in cursor:
-            app['variables'].append(row['name'])
-            if row['required']:
-                app['required_variables'].append(row['name'])
-            if row['title_variable']:
-                app['title_variable'] = row['name']
-
-        cursor.execute(get_default_application_modes_query, app_name)
-        app['default_modes'] = {row['priority']: row['mode'] for row in cursor}
-
-        cursor.execute(get_supported_application_modes_query, app['id'])
-        app['supported_modes'] = [row['name'] for row in cursor]
-
-        cursor.execute(get_application_custom_sender_addresses, app['id'])
-        app['custom_sender_addresses'] = {row['mode_name']: row['address'] for row in cursor}
-
-        cursor.execute(get_application_categories, app['id'])
-        app['categories'] = [row for row in cursor]
-
-        cursor.close()
-        connection.close()
-
-        payload = app
-        resp.status = HTTP_200
-        resp.body = ujson.dumps(payload)
-
-
 class InternalApplicationsAuth(object):
     allow_read_no_auth = False
 
@@ -5552,7 +5498,6 @@ def construct_falcon_api(debug, healthcheck_path, allowed_origins, iris_sender_a
     api.add_route('/v0/users/{username}/slackid', UserToSlackID(config))
     api.add_route('/v0/users/{username}/categories/{application}', CategoryOverrides())
 
-    api.add_route('/v0/internal/applications/{app_name}', InternalApplications(config))
     api.add_route('/v0/internal/auth/applications', InternalApplicationsAuth(config))
 
     mobile_config = config.get('iris-mobile', {})

--- a/test/e2etest.py
+++ b/test/e2etest.py
@@ -2153,7 +2153,7 @@ def test_get_user(sample_user, sample_email, sample_admin_user):
     re = requests.get(base_url + 'users/' + sample_user, headers=username_header(sample_user))
     assert re.status_code == 200
     data = re.json()
-    assert data.keys() == {'teams', 'modes', 'per_app_modes', 'admin', 'contacts', 'name', 'template_overrides'}
+    assert data.keys() == {'teams', 'modes', 'per_app_modes', 'admin', 'contacts', 'name', 'template_overrides', 'device', 'category_overrides'}
     assert data['contacts']['email'] == sample_email
     assert data['name'] == sample_user
 


### PR DESCRIPTION
- adds internal API endpoint to return all application auth details for use by a custom sender that does not have direct access to the database
- add a category override and device registration information to user endpoint