### PR TITLE
Allow previous 30 second hmac window

### DIFF
--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -876,6 +876,7 @@ class AuthMiddleware(object):
                     now // 5,
                     (now // 5) - 1,
                     now // 30,
+                    (now // 30) - 1,
                 ]
                 for api_key in (str(app['key']), str(app['secondary_key'])):
                     for window in windows:


### PR DESCRIPTION
If a request happens at the very end of our 30 second window, even a
minimal amount of clock drift may cause validation to fail.

Allow the previous 30 second window as well, to avoid this problem.