### PR TITLE
change cache plan delete log level

### DIFF
--- a/src/iris/sender/cache.py
+++ b/src/iris/sender/cache.py
@@ -310,10 +310,11 @@ class Plans():
         new_ids = new_active_ids - old_active_ids
 
         for plan_id in old_ids:
-            try:
-                del self.data[plan_id]
-            except KeyError:
-                logger.exception('Failed pruning old plan_id %s', plan_id)
+            if self.data.get(plan_id):
+                try:
+                    del self.data[plan_id]
+                except KeyError:
+                    logger.debug('Failed pruning old plan_id %s', plan_id)
 
         Pool(30).map(self.__getitem__, (active[id] for id in new_ids))
 


### PR DESCRIPTION
- it is possible for multiple iris-api workers can share a cache and call the refresh method simultaneously and trying to delete the same key twice leading to a keyerror exception to be logged. Check to see if key exists first and lower loglevel of the error