### PR TITLE
Optionally forward notification requests to external sender and return internal incidents as dictionary

### DIFF
--- a/configs/config.dev.yaml
+++ b/configs/config.dev.yaml
@@ -104,6 +104,15 @@ webhooks:
 # allowlisted_internal_apps:
 #   - iris-internal-application
 
+## configs for external sender
+## THIS FUNCTIONALITY IS CURRENTLY UNRELEASED, LEAVE COMMENTED
+# external_sender:
+#   external_sender_enabled: True
+#   external_sender_address: "https://127.0.0.1:14724"
+#   external_sender_app: 'iris'
+#   external_sender_key: '1234'
+#   external_sender_version: 0
+
 #####################
 ### Iris-sender
 #####################

--- a/src/iris/bin/sender.py
+++ b/src/iris/bin/sender.py
@@ -926,9 +926,7 @@ def set_target_contact(message):
             # message triggered by incident will only have priority
             result, message = set_target_contact_by_priority(message)
         if result:
-            if cache.target_reprioritization is None:
-                message = cache.TargetReprioritization(db.engine)(message)
-            else:
+            if cache.target_reprioritization is not None:
                 message = cache.target_reprioritization(message)
         else:
             logger.warning('target does not have mode %r', message)

--- a/src/iris/bin/sender.py
+++ b/src/iris/bin/sender.py
@@ -926,7 +926,10 @@ def set_target_contact(message):
             # message triggered by incident will only have priority
             result, message = set_target_contact_by_priority(message)
         if result:
-            message = cache.target_reprioritization(message)
+            if cache.target_reprioritization is None:
+                message = cache.TargetReprioritization(db.engine)(message)
+            else:
+                message = cache.target_reprioritization(message)
         else:
             logger.warning('target does not have mode %r', message)
             result, message = set_target_fallback_mode(message)
@@ -963,7 +966,11 @@ def render(message):
             message['body'] = ''
         error = None
         try:
-            template = cache.templates[message['template']]
+            template = None
+            if cache.templates is None:
+                template = cache.Templates(db.engine)[message['template']]
+            else:
+                template = cache.templates[message['template']]
             try:
                 application_template = template[message['application']]
                 try:

--- a/src/iris/client.py
+++ b/src/iris/client.py
@@ -24,7 +24,7 @@ class IrisAuth(requests.auth.AuthBase):
         path = request.path_url.encode('utf8')
         method = request.method.encode('utf8')
         body = request.body or b''
-        window = str(int(time.time()) // 5).encode('utf8')
+        window = str(int(time.time()) // 30).encode('utf8')
         HMAC.update(b'%s %s %s %s' % (window, method, path, body))
 
         digest = base64.urlsafe_b64encode(HMAC.digest())


### PR DESCRIPTION
- forward notifications to external sender
- return internal incident endpoint as a dictionary
- set window to 30 seconds for HMAC client 
- fix issue with uninitialized cache queries