### PR TITLE
db setup instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Iris core, API, UI and sender service. For third-party integration support, see 
 Setup database
 --------------
 
-1. remove `ONLY_FULL_GROUP_BY` from MySQL config `sql_mode`
-1. create mysql schema: `mysql -u USER -p < ./db/schema_0.sql`
+1. remove `ONLY_FULL_GROUP_BY` from MySQL config `sql_mode` or run mysqld in permisive mode (i.e. `--sql_mode=''`)
+1. create mysql schema: `mysql -u USER -p < ./db/schema_0.sql`  (WARNING: This will drop any existing tables)
 1. import dummy data: `mysql -u USER -p -o iris < ./db/dummy_data.sql`
 
 `dummy_data.sql` contains the following entities:


### PR DESCRIPTION
the `schema_0.sql` contains `drop table` statement which could be not obvious.

I experienced this issue when using a docker image with `DOCKER_DB_BOOTSTRAP=1` (which does a schema and dummy data), and wondering why I lost all my custom plans and templates, after iris container restart.

Additionally provide alternative way to removing ONLY_FULL_GROUP_BY. This is useful when running mysql docker images. I.e. from oracla/mysql or bitnami mariadb images. This is easier than modifying the config file, or changing global server configuration when running in the container (i.e. docker or kubernetes).