### PR TITLE
rebasing container image to ubuntu:20.04

### DIFF
--- a/ops/daemons/uwsgi-docker.yaml
+++ b/ops/daemons/uwsgi-docker.yaml
@@ -1,5 +1,5 @@
 prod:
-    plugins: python,logfile,gevent_python
+    plugins: python3,logfile,gevent_python3
     chdir: /home/iris/source/src
     socket: /home/iris/var/run/uwsgi.sock
     chmod-socket: 666
@@ -8,7 +8,7 @@ prod:
     # uid: 1000
     # gid: 1000
     workers: 12
-    gevent: 100
+    #gevent: 100 # workers die, if specified with gevent_python3 (why?)
     lazy-apps: true
     master-fifo: /home/iris/var/run/uwsgi_master_fifo
     touch-reload: /home/iris/var/run/uwsgi_touch_reload

--- a/ops/entrypoint.py
+++ b/ops/entrypoint.py
@@ -88,7 +88,9 @@ def main():
             initialize_mysql_schema(mysql_config)
 
     os.execv('/usr/bin/uwsgi',
-             ['', '--yaml', os.environ.get('UWSGI_CONFIG', '/home/iris/daemons/uwsgi.yaml:prod')])
+             # first array element is ARGV0, since python 3.6 it cannot be empty, using space
+             # https://bugs.python.org/issue28732
+             [' ', '--yaml', os.environ.get('UWSGI_CONFIG', '/home/iris/daemons/uwsgi.yaml:prod')])
 
 
 if __name__ == '__main__':

--- a/ops/packer/Makefile
+++ b/ops/packer/Makefile
@@ -1,0 +1,10 @@
+.PHONY: all version docker
+
+all: docker
+
+version:
+	mkdir -p output
+	python gen_packer_cfg.py ./iris.yaml | tail -n +2 > ./output/iris.json
+
+docker: version
+	packer build -only=docker ./output/iris.json

--- a/ops/packer/README.md
+++ b/ops/packer/README.md
@@ -25,6 +25,11 @@ Build Docker image:
 packer build -only=docker ./output/iris.json
 ```
 
+or use
+
+```bash
+make docker
+```
 
 Usage
 -----

--- a/ops/packer/iris.yaml
+++ b/ops/packer/iris.yaml
@@ -94,7 +94,8 @@ provisioners:
 
   - type: "shell"
     inline:
-      - 'sudo apt -y install python3 python3-pip python3-virtualenv && sudo apt -y install libldap2-dev libsasl2-dev && DEBIAN_FRONTEND=noninteractive sudo -E apt -y install nginx uwsgi uwsgi-plugin-python3 uwsgi-plugin-gevent-python3 && sudo rm -rf /var/cache/apt/archives/*'
+      # for ubuntu:20.04, Python 3.8 is used
+      - 'DEBIAN_FRONTEND=noninteractive sudo -E apt -y install python3 python3-pip python3-virtualenv && DEBIAN_FRONTEND=noninteractive sudo -E apt -y install libldap2-dev libsasl2-dev && DEBIAN_FRONTEND=noninteractive sudo -E apt -y install nginx uwsgi uwsgi-plugin-python3 uwsgi-plugin-gevent-python3 && DEBIAN_FRONTEND=noninteractive sudo -E apt -y install mysql-client && sudo rm -rf /var/cache/apt/archives/*'
       - sudo useradd -m -s /bin/bash iris
       - sudo chown -R iris:iris /home/iris /var/log/nginx /var/lib/nginx
       - sudo -Hu iris mkdir -p /home/iris/var/log/uwsgi /home/iris/var/log/nginx /home/iris/var/run

--- a/ops/packer/iris.yaml
+++ b/ops/packer/iris.yaml
@@ -45,9 +45,10 @@ builders:
       version: '{{ user `app_version` }}'
 
   - type: "docker"
-    image: "ubuntu:16.04"
+    image: "ubuntu:20.04"
     changes:
       - 'EXPOSE 16649'
+      - "ENTRYPOINT []"
       - 'CMD ["sudo", "-EHu", "iris", "bash", "-c", "source /home/iris/env/bin/activate && python /home/iris/entrypoint.py"]'
     commit: True
 
@@ -64,6 +65,10 @@ provisioners:
   - type: "file"
     source: "../../setup.py"
     destination: "/tmp/repo/setup.py"
+  
+  - type: "file"
+    source: "../../README.md"
+    destination: "/tmp/repo/README.md"
 
   - type: "file"
     source: "../../db"
@@ -80,7 +85,7 @@ provisioners:
   - type: "shell"
     only: ["docker"]
     inline:
-      - "apt-get update && apt-get -y install sudo"
+      - "apt update && apt -y install sudo"
 
   - type: "shell"
     only: ["amazon-ebs"]
@@ -89,7 +94,7 @@ provisioners:
 
   - type: "shell"
     inline:
-      - 'sudo apt-get -y install curl python-pip uwsgi unzip virtualenv sudo python-dev libyaml-dev libsasl2-dev libldap2-dev nginx uwsgi-plugin-python uwsgi-plugin-gevent-python mysql-client && sudo rm -rf /var/cache/apt/archives/*'
+      - 'sudo apt -y install python3 python3-pip python3-virtualenv && sudo apt -y install libldap2-dev libsasl2-dev && DEBIAN_FRONTEND=noninteractive sudo -E apt -y install nginx uwsgi uwsgi-plugin-python3 uwsgi-plugin-gevent-python3 && sudo rm -rf /var/cache/apt/archives/*'
       - sudo useradd -m -s /bin/bash iris
       - sudo chown -R iris:iris /home/iris /var/log/nginx /var/lib/nginx
       - sudo -Hu iris mkdir -p /home/iris/var/log/uwsgi /home/iris/var/log/nginx /home/iris/var/run


### PR DESCRIPTION
* switching to Python v3
  * which was driven by rsa>=3.1.4 -> oauth2client==1.4.12, it no longer supports Python v2
* adding ops/packer Makefile
  * to automate steps only found in README.md
  * done just for the docker image build
* instructing packer to clear ENTRYPOINT from original ubuntu image
  * CMD was not working with the /bin/sh in place of ENTRYPOINT