### PR TITLE
use DB port from the config in image entrypoint

### DIFF
--- a/ops/entrypoint.py
+++ b/ops/entrypoint.py
@@ -15,9 +15,12 @@ initializedfile = os.environ.get('INIT_FILE', '/home/iris/db_initialized')
 
 def load_sqldump(config, sqlfile, one_db=True):
     print('Importing %s...' % sqlfile)
+    effective_port = 3306
+    if 'port' in config:
+        effective_port = config['port']
     with open(sqlfile) as h:
         cmd = ['/usr/bin/mysql', '-h', config['host'], '-u',
-               config['user'], '-p' + config['password']]
+               config['user'], '-p' + config['password'], '-P' + str(effective_port)]
         if one_db:
             cmd += ['-o', config['database']]
         proc = subprocess.Popen(cmd, stdin=h)
@@ -35,7 +38,12 @@ def load_sqldump(config, sqlfile, one_db=True):
 
 def wait_for_mysql(config):
     print('Checking MySQL liveness on %s...' % config['host'])
-    db_address = (config['host'], 3306)
+
+    effective_port = 3306
+    if 'port' in config:
+        effective_port = config['port']
+
+    db_address = (config['host'], effective_port)
     tries = 0
     while True:
         try:


### PR DESCRIPTION
* until now, 3306 was hardcoded
* port in config file stays optional for backward compatibility