### PR TITLE
Calculate incident priority for incident creation hook

### DIFF
--- a/src/iris/constants.py
+++ b/src/iris/constants.py
@@ -13,3 +13,7 @@ EMAIL_SUPPORT = 'email'
 IM_SUPPORT = 'im'
 SLACK_SUPPORT = 'slack'
 HIPCHAT_SUPPORT = 'hipchat'
+
+# Priorities listed in order of severity, ascending
+PRIORITY_PRECEDENCE = ('low', 'medium', 'high', 'urgent')
+PRIORITY_PRECEDENCE_MAP = {name: index for index, name in enumerate(PRIORITY_PRECEDENCE)}


### PR DESCRIPTION
- Generate priority by looking for the highest severity priority across
  all of the plan notifications

- Set this as a new priority field within the incident details as passed
  to the process_create() hook