### PR TITLE
Don't prepend https:// to proxy hostnames (add support for newer urllib3/requests)

### DIFF
--- a/src/iris/push/fcm.py
+++ b/src/iris/push/fcm.py
@@ -20,8 +20,8 @@ class fcm(object):
         if 'proxy' in self.config:
             host = self.config['proxy']['host']
             port = self.config['proxy']['port']
-            self.proxy = {'http': 'http://%s:%s' % (host, port),
-                          'https': 'https://%s:%s' % (host, port)}
+            self.proxy = {'http': '%s:%s' % (host, port),
+                          'https': '%s:%s' % (host, port)}
         self.client = FCMNotification(api_key=self.api_key, proxy_dict=self.proxy)
 
     def send_push(self, message):

--- a/src/iris/vendors/iris_hipchat.py
+++ b/src/iris/vendors/iris_hipchat.py
@@ -21,8 +21,8 @@ class iris_hipchat(object):
         if 'proxy' in self.config:
             host = self.config['proxy']['host']
             port = self.config['proxy']['port']
-            self.proxy = {'http': 'http://%s:%s' % (host, port),
-                          'https': 'https://%s:%s' % (host, port)}
+            self.proxy = {'http': '%s:%s' % (host, port),
+                          'https': '%s:%s' % (host, port)}
         self.token = self.config.get('auth_token')
         self.room_id = int(self.config.get('room_id'))
         self.debug = self.config.get('debug')

--- a/src/iris/vendors/iris_messagebird.py
+++ b/src/iris/vendors/iris_messagebird.py
@@ -25,8 +25,8 @@ class iris_messagebird(object):
         if 'proxy' in self.config:
             host = self.config['proxy']['host']
             port = self.config['proxy']['port']
-            self.proxy = {'http': 'http://%s:%s' % (host, port),
-                          'https': 'https://%s:%s' % (host, port)}
+            self.proxy = {'http': '%s:%s' % (host, port),
+                          'https': '%s:%s' % (host, port)}
 
         base_url = 'https://rest.messagebird.com'
         self.endpoint_url_messages = base_url + '/messages'

--- a/src/iris/vendors/iris_slack.py
+++ b/src/iris/vendors/iris_slack.py
@@ -26,8 +26,8 @@ class iris_slack(object):
         if 'proxy' in self.config:
             host = self.config['proxy']['host']
             port = self.config['proxy']['port']
-            self.proxy = {'http': 'http://%s:%s' % (host, port),
-                          'https': 'https://%s:%s' % (host, port)}
+            self.proxy = {'http': '%s:%s' % (host, port),
+                          'https': '%s:%s' % (host, port)}
         self.timeout = config.get('timeout', 10)
         self.sleep_range = config.get('sleep_range', 4)
         self.message_attachments = self.config.get('message_attachments', {})


### PR DESCRIPTION
Historically, this approach has always worked because http forward proxies
generally only listen on http:// (not https://) and urllib3 has not supported
connecting to a http proxy via https:// so it has always ignored the scheme.

However, as of urllib3 >= 1.26 or so, urllib3 does support and attempt connecting
to proxies via https:// (if this schem is provided) and it raises an exception
if the proxy only listens on http://

Fix this by no longer enforcing a http:// prefix to proxy hostnames. If the user
wants to connect to a https:// proxy, this prefix can be provided within Iris's
configuration. If no prefix is provided, urllib3/requests defaults to http://