### PR TITLE
do not load configs within util

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,10 @@ docs:
 	make -C docs html
 
 e2e:
-	export IRISPYTEST=True; py.test -rxs -vv ./test/e2etest.py
+	py.test -rxs -vv ./test/e2etest.py
 
 unit:
-	export IRISPYTEST=True; py.test -vv test
+	py.test -vv test
 
 flake8:
 	flake8 src test setup.py

--- a/src/iris/utils.py
+++ b/src/iris/utils.py
@@ -9,9 +9,7 @@ from phonenumbers import (format_number as pn_format_number, parse as pn_parse,
 from gevent import sleep
 import datetime
 import ujson
-import os
 from . import db
-from iris.config import load_config
 import re
 import msgpack
 import logging
@@ -19,18 +17,15 @@ from random import randrange
 
 logger = logging.getLogger(__name__)
 
-config = {}
-if 'IRISPYTEST' not in os.environ:
-    config = load_config()
-
+BUCKET_ID_MAX = 100
 uuid4hex = re.compile('[0-9a-f]{32}\Z', re.I)
 allowed_text_response_actions = frozenset(['suppress', 'claim'])
 
 
 def generate_bucket_id():
-    # returns random integer value value from 0 to number_of_bucket-1, inclusive.
-    bucket_id_max = config.get("iris-message-processor", {}).get("number_of_buckets", 100)
-    return randrange(bucket_id_max)
+    # returns random integer value value from 0 to BUCKET_ID_MAX-1, inclusive.
+    # TODO properly mock config loading in testing to not rely on environmental variables and make this configurable in configs
+    return randrange(BUCKET_ID_MAX)
 
 
 def normalize_phone_number(num):


### PR DESCRIPTION
BUCKET_ID_MAX will never change unless there was a need to run > 100 instances of Iris Message Processor which shouldn't ever be the case. The current method of setting an environmental variable for testing can cause issues with deployments so set bucket quantity to a constant for now. Eventually we should properly set up mocking for config loading in testing. Currently util is imported by libraries that are imported in testing files and load_configs is called before any testing code is run so adding a simple pytest fixture in the test file is not enough.