### PR TITLE
use locks with api cache

### DIFF
--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -1554,6 +1554,7 @@ class Incidents(object):
         - application: Application that created this incident (string)
         - plan: Escalation plan name (string)
         - plan_id: Escalation plan id (int)
+        - claimed: Claimed status (bool)
 
         This endpoint also allows specification of a limit via another query parameter, which limits
         results to the N most recent incidents. Calls to this endpoint that do not specify either a limit
@@ -1579,6 +1580,13 @@ class Incidents(object):
         connection = db.engine.raw_connection()
         where = gen_where_filter_clause(connection, incident_filters, incident_filter_types, req.params)
         sql_values = []
+        claimed_filter = req.get_param_as_bool('claimed')
+        if claimed_filter is not None:
+            if claimed_filter:
+                where.append('''`incident`.`owner_id` IS NOT NULL''')
+            else:
+                where.append('''`incident`.`owner_id` IS NULL''')
+
         if target and not self.external_sender_incident_processing:
             where.append('''`message`.`target_id` IN
                 (SELECT `id`

--- a/src/iris/cache.py
+++ b/src/iris/cache.py
@@ -3,7 +3,7 @@
 
 from . import db
 import logging
-import threading
+import gevent
 
 logger = logging.getLogger(__name__)
 
@@ -13,7 +13,7 @@ target_types = {}  # name -> id
 target_roles = {}  # name -> id
 modes = {}         # name -> id
 slack_ids = {}     # name -> id
-api_cache_lock = threading.Lock()
+api_cache_lock = gevent.lock.Semaphore(1)
 
 
 def cache_applications():
@@ -48,9 +48,8 @@ def cache_applications():
                           WHERE `application_id` = %s''', app['id'])
         app['categories'] = {row['name']: row for row in cursor}
         new_applications[app['name']] = app
-    api_cache_lock.acquire()
-    applications = new_applications
-    api_cache_lock.release()
+    with api_cache_lock:
+        applications = new_applications
     connection.close()
     cursor.close()
     logger.debug('Loaded applications: %s', ', '.join(applications))
@@ -62,9 +61,8 @@ def cache_priorities():
     cursor = connection.cursor(db.dict_cursor)
     cursor.execute('''SELECT `priority`.`id`, `priority`.`name`, `priority`.`mode_id`
                       FROM `priority`''')
-    api_cache_lock.acquire()
-    priorities = {row['name']: row for row in cursor}
-    api_cache_lock.release()
+    with api_cache_lock:
+        priorities = {row['name']: row for row in cursor}
     cursor.close()
     connection.close()
 
@@ -74,9 +72,8 @@ def cache_target_types():
     connection = db.engine.raw_connection()
     cursor = connection.cursor()
     cursor.execute('''SELECT `name`, `id` FROM target_type''')
-    api_cache_lock.acquire()
-    target_types = dict(cursor)
-    api_cache_lock.release()
+    with api_cache_lock:
+        target_types = dict(cursor)
     cursor.close()
     connection.close()
 
@@ -86,9 +83,8 @@ def cache_target_roles():
     connection = db.engine.raw_connection()
     cursor = connection.cursor()
     cursor.execute('''SELECT `name`, `id` FROM target_role''')
-    api_cache_lock.acquire()
-    target_roles = dict(cursor)
-    api_cache_lock.release()
+    with api_cache_lock:
+        target_roles = dict(cursor)
     cursor.close()
     connection.close()
 
@@ -98,9 +94,8 @@ def cache_modes():
     connection = db.engine.raw_connection()
     cursor = connection.cursor()
     cursor.execute('''SELECT `name`, `id` FROM mode''')
-    api_cache_lock.acquire()
-    modes = dict(cursor)
-    api_cache_lock.release()
+    with api_cache_lock:
+        modes = dict(cursor)
     cursor.close()
     connection.close()
 
@@ -108,9 +103,8 @@ def cache_modes():
 def add_slack_id(username, slack_id):
     global slack_ids
     # slack ids shouldn't change so we don't have to worry about refreshing them
-    api_cache_lock.acquire()
-    slack_ids[username] = slack_id
-    api_cache_lock.release()
+    with api_cache_lock:
+        slack_ids[username] = slack_id
 
 
 def init():


### PR DESCRIPTION
add a threading lock to the api cache to fix a bug where request from known good application can fail authentication with `Tried authenticating with nonexistent app: "app_foo"` when api cache is being updated. 