### PR TITLE
correctly return no incidents when filtering by target and no messages are found

### DIFF
--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -1607,6 +1607,11 @@ class Incidents(object):
                             incident_IDs.append(message.get('incident_id'))
                         where.append('''`incident`.`id` IN %s''')
                         sql_values.append(tuple(incident_IDs))
+                    elif target:
+                        # if target field is specified and there are no matching messages that means there are no incidents that match the query
+                        resp.status = HTTP_200
+                        resp.body = ujson.dumps([])
+                        return
                 else:
                     logger.error('failed retrieving messages from external sender %s', r.text)
             except Exception as e:


### PR DESCRIPTION
The way the target field is matched to incidents is by checking if there are any messages belonging to that incident sent out to that target. If query is using that filter and no messages are found correctly return no matching incidents.