### PR TITLE
Fix up docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,10 +7,13 @@ services:
       - "16649:16649"
     environment:
       - DOCKER_DB_BOOTSTRAP=1
+      - IRIS_CFG_DB_HOST=mysql
+      - IRIS_CFG_DB_PASSWORD=1234
     volumes:
       - ./configs/config.dev.yaml:/home/iris/config/config.yaml
 
   iris-mysql:
     image: mysql:5.5
+    hostname: mysql
     environment:
       - MYSQL_ROOT_PASSWORD=1234


### PR DESCRIPTION
This fixes a couple of issues with the Docker compose demo.
Setting the domain and password enables the web server to connect to mysql.

Steps to reproduce/test fix:

```
docker compose up
```

Errors seen:

```
iris-web_1    | DB not up yet. Waiting a few seconds..
iris-web_1    | Waited too long for DB to come up. Bailing.

Enter password: ERROR 1045 (28000): Access denied for user 'root'@'172.18.0.3' (using password: YES)
```

Following this I needed to run these bootstrapping commands:

```
docker exec -it $(docker ps -f name=iris_iris-web_1 -q) bash

mysql -u root --host mysql -p < ./db/schema_0.sql
mysql -u root --host mysql -p -o iris < ./db/dummy_data.sql
```