### PR TITLE
Call gevent.monkey.patch_all immediately on import

### DIFF
--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -1,6 +1,7 @@
 # Copyright (c) LinkedIn Corporation. All rights reserved. Licensed under the BSD-2 Clause license.
 # See LICENSE in the project root for license information.
-from gevent import spawn, sleep, socket, Timeout
+from gevent import spawn, sleep, socket, Timeout, monkey
+monkey.patch_all() # NOQA
 
 import msgpack
 import time


### PR DESCRIPTION
The api makes use of [gevent], a coroutine based networking library which relies heavily on monkey patching the stdlib.

From the [gevent.monkey] docs:
> Warning Patching too late can lead to unreliable behaviour
> (for example, some modules may still use blocking sockets) or even errors.

This appears to have happened here. Thanks to @allwyn-pradip for pointing me at the right file in PR https://github.com/linkedin/iris/pull/690!

Monkey-patching immediately resolves #686, #699, #644.

Blog on gevent: https://eng.lyft.com/what-the-heck-is-gevent-4e87db98a8
> In the case of gevent — monkey patching has to be the absolute first thing a process does

[gevent]: https://www.gevent.org/index.html
[gevent.monkey]: https://www.gevent.org/api/gevent.monkey.html