### PR TITLE
fix sms/slack claim all functionality

### DIFF
--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -1607,6 +1607,11 @@ class Incidents(object):
                             incident_IDs.append(message.get('incident_id'))
                         where.append('''`incident`.`id` IN %s''')
                         sql_values.append(tuple(incident_IDs))
+                    elif target:
+                        # if target field is specified and there are no matching messages that means there are no incidents that match the query
+                        resp.status = HTTP_200
+                        resp.body = ujson.dumps([])
+                        return
                 else:
                     logger.error('failed retrieving messages from external sender %s', r.text)
             except Exception as e:

--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -5968,6 +5968,9 @@ class InternalBuildMessages():
             if 'context' not in notification:
                 logger.warning('Failed to build due to missing context from app %s', notification['application'])
                 raise HTTPBadRequest('INVALID context')
+            elif 'iris' not in notification.get('context', {}):
+                # fill in dummy iris meta data for OOB notifications messages
+                notification['context']['iris'] = {}
         elif 'email_html' in notification:
             if not isinstance(notification['email_html'], str):
                 logger.warning('Failed to build with invalid email_html from app %s: %s', notification['application'], notification['email_html'])

--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -5913,7 +5913,6 @@ class InternalBuildMessages():
             cursor.close()
             conn.close()
 
-        notification['subject'] = '[%s] %s' % (notification['application'], notification.get('subject', ''))
         target_list = notification.get('target_list')
         role = notification.get('role')
         if not role and not target_list:

--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -5847,6 +5847,36 @@ class CategoryOverrides(object):
         resp.status = HTTP_204
 
 
+class InternalRenderJinja():
+    allow_read_no_auth = True
+    internal_allowlist_only = False
+
+    def __init__(self):
+        # Autoescape needs to be False to avoid html-encoding ampersands in emails.
+        # in emails, html is allowed and ampersands are escaped with markdown's renderer.
+        self.env = SandboxedEnvironment(autoescape=False)
+
+    def on_get(self, req, resp):
+        req_body = ujson.loads(req.context['body'])
+        if 'template_str' not in req_body or 'context' not in req_body:
+            raise HTTPBadRequest('Missing required attributes, must have template_str and context')
+        template_str = req_body.get('template_str')
+        context = req_body.get('context')
+
+        try:
+            render_env = self.env.from_string(template_str)
+        except Exception as e:
+            raise HTTPBadRequest('Failed to render jinja with err: %s' % str(e))
+        else:
+            try:
+                rendered_body = render_env.render(**context)
+            except Exception as e:
+                raise HTTPBadRequest('Failed to render jinja with err: %s' % str(e))
+
+        resp.status = HTTP_200
+        resp.body = ujson.dumps({"rendered_body": rendered_body})
+
+
 class InternalBuildMessages():
     allow_read_no_auth = False
     internal_allowlist_only = True
@@ -6550,6 +6580,7 @@ def construct_falcon_api(debug, healthcheck_path, allowed_origins, iris_sender_a
     api.add_route('/v0/internal/target', InternalTarget(config))
     api.add_route('/v0/internal/plan_aggregation_settings', PlanAggregationSettings())
     api.add_route('/v0/internal/build_message', InternalBuildMessages(config))
+    api.add_route('/v0/internal/render_jinja', InternalRenderJinja())
     api.add_route('/v0/internal/sender_heartbeat/{node_id}', SenderHeartbeat(config))
     api.add_route('/v0/internal/incidents/{node_id}', InternalIncidents(config))
     api.add_route('/v0/internal/sender_peer_count', SenderPeerCount())

--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -5968,9 +5968,6 @@ class InternalBuildMessages():
             if 'context' not in notification:
                 logger.warning('Failed to build due to missing context from app %s', notification['application'])
                 raise HTTPBadRequest('INVALID context')
-            else:
-                # fill in dummy iris meta data
-                notification['context']['iris'] = {}
         elif 'email_html' in notification:
             if not isinstance(notification['email_html'], str):
                 logger.warning('Failed to build with invalid email_html from app %s: %s', notification['application'], notification['email_html'])

--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -4813,7 +4813,7 @@ def handle_response_external(self, response, mode, source):
     if claim_last:
         last_day_date_time = datetime.datetime.now() - datetime.timedelta(hours=24)
         date_timestamp = int((time.mktime(last_day_date_time.timetuple())))
-        r = external_sender_client.get('messages?active=1&target=%s&created__ge=%d' % (target_name, date_timestamp), verify=self.verify)
+        r = external_sender_client.get('messages?incident_id__ne=0&active=1&target=%s&created__ge=%d' % (target_name, date_timestamp), verify=self.verify)
         if r.ok:
             messages = r.json()
             incident_ids = []
@@ -4833,7 +4833,7 @@ def handle_response_external(self, response, mode, source):
     elif claim_all:
         last_day_date_time = datetime.datetime.now() - datetime.timedelta(hours=24)
         date_timestamp = int((time.mktime(last_day_date_time.timetuple())))
-        r = external_sender_client.get('messages?active=1&target=%s&created__ge=%d' % (target_name, date_timestamp), verify=self.verify)
+        r = external_sender_client.get('messages?incident_id__ne=0&active=1&target=%s&created__ge=%d' % (target_name, date_timestamp), verify=self.verify)
         if r.ok:
             messages = r.json()
             incident_ids = []

--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -5968,7 +5968,7 @@ class InternalBuildMessages():
             if 'context' not in notification:
                 logger.warning('Failed to build due to missing context from app %s', notification['application'])
                 raise HTTPBadRequest('INVALID context')
-            elif 'iris' not in notification.get('context', {}):
+            elif 'iris' not in notification['context']:
                 # fill in dummy iris meta data for OOB notifications messages
                 notification['context']['iris'] = {}
         elif 'email_html' in notification:

--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -4786,9 +4786,9 @@ def handle_response_external(self, response, mode, source):
     if response.lower().startswith('f'):
         return 'Sincerest apologies'
     # One-letter shortcuts for claim all/last
-    elif response.lower() == 'a':
+    elif response.lower() == 'a' or 'all' in response.lower():
         claim_all = True
-    elif response.lower() == 'l':
+    elif response.lower() == 'l' or 'last' in response.lower():
         claim_last = True
 
     incident_id = ""
@@ -4802,25 +4802,15 @@ def handle_response_external(self, response, mode, source):
         elif halves[1].lower() == 'claim' and halves[0].isdigit():
             incident_id = halves[0]
 
+        active_incidents = utils.get__active_incidents_from_incident_id_list([incident_id])
+        if len(active_incidents) == 0:
+            return 'Incident with ID: %s is not currently an active incident' % incident_id
         # get incident id from external sender and claim it
         if incident_id != "":
             utils.claim_incident(incident_id, target_name)
             return 'claimed: %s' % incident_id
 
-    if claim_last or response.lower() == 'claim all':
-        r = external_sender_client.get('messages?active=1&limit=1&target=%s' % target_name, verify=self.verify)
-        if r.ok:
-            messages = r.json()
-            incident_ids = []
-            for message in messages:
-                incident_ids.append(message.get('incident_id', ''))
-            utils.claim_bulk_incidents(incident_ids, target_name)
-            return 'claimed: %s' % incident_ids
-        else:
-            logger.error("failed retrieving messages from external sender: %s", r.text)
-            return 'could not resolve action'
-
-    elif claim_all or response.lower() == 'claim all':
+    if claim_last:
         last_day_date_time = datetime.datetime.now() - datetime.timedelta(hours=24)
         date_timestamp = int((time.mktime(last_day_date_time.timetuple())))
         r = external_sender_client.get('messages?active=1&target=%s&created__ge=%d' % (target_name, date_timestamp), verify=self.verify)
@@ -4829,8 +4819,33 @@ def handle_response_external(self, response, mode, source):
             incident_ids = []
             for message in messages:
                 incident_ids.append(message.get('incident_id', ''))
-            utils.claim_bulk_incidents(incident_ids, target_name)
-            return 'claimed: %s' % incident_ids
+            if len(incident_ids) == 0:
+                return 'found no active incidents to claim at this time'
+            active_incidents = utils.get__active_incidents_from_incident_id_list(incident_ids)
+            if len(active_incidents) == 0:
+                return 'found no active incidents to claim at this time'
+            utils.claim_incident(max(active_incidents), target_name)
+            return 'claimed: %s' % max(active_incidents)
+        else:
+            logger.error("failed retrieving messages from external sender: %s", r.text)
+            return 'could not resolve action'
+
+    elif claim_all:
+        last_day_date_time = datetime.datetime.now() - datetime.timedelta(hours=24)
+        date_timestamp = int((time.mktime(last_day_date_time.timetuple())))
+        r = external_sender_client.get('messages?active=1&target=%s&created__ge=%d' % (target_name, date_timestamp), verify=self.verify)
+        if r.ok:
+            messages = r.json()
+            incident_ids = []
+            for message in messages:
+                incident_ids.append(message.get('incident_id', ''))
+            if len(incident_ids) == 0:
+                return 'found no active incidents to claim at this time'
+            active_incidents = utils.get__active_incidents_from_incident_id_list(incident_ids)
+            if len(active_incidents) == 0:
+                return 'found no active incidents to claim at this time'
+            utils.claim_bulk_incidents(active_incidents, target_name)
+            return 'claimed: %s' % active_incidents
         else:
             logger.error("failed retrieving messages from external sender: %s", r.text)
             return 'could not resolve action'

--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -5848,8 +5848,8 @@ class CategoryOverrides(object):
 
 
 class InternalRenderJinja():
-    allow_read_no_auth = True
-    internal_allowlist_only = False
+    allow_read_no_auth = False
+    internal_allowlist_only = True
 
     def __init__(self):
         # Autoescape needs to be False to avoid html-encoding ampersands in emails.

--- a/src/iris/utils.py
+++ b/src/iris/utils.py
@@ -144,6 +144,7 @@ def get_incident_ids_from_message_ids(msg_ids):
     connection.close()
     return ret
 
+
 def get__active_incidents_from_incident_id_list(incident_ids):
     sql = 'SELECT `incident`.`id` FROM `incident` WHERE `incident`.`active` = 1 AND `incident`.`id` IN %s'
     connection = db.engine.raw_connection()
@@ -153,6 +154,7 @@ def get__active_incidents_from_incident_id_list(incident_ids):
     cursor.close()
     connection.close()
     return ret
+
 
 def get_incident_context_from_message_id(msg_id):
     sql = '''SELECT `incident`.`context`

--- a/src/iris/utils.py
+++ b/src/iris/utils.py
@@ -144,6 +144,15 @@ def get_incident_ids_from_message_ids(msg_ids):
     connection.close()
     return ret
 
+def get__active_incidents_from_incident_id_list(incident_ids):
+    sql = 'SELECT `incident`.`id` FROM `incident` WHERE `incident`.`active` = 1 AND `incident`.`id` IN %s'
+    connection = db.engine.raw_connection()
+    cursor = connection.cursor()
+    cursor.execute(sql, (tuple(incident_ids), ))
+    ret = [row[0] for row in cursor]
+    cursor.close()
+    connection.close()
+    return ret
 
 def get_incident_context_from_message_id(msg_id):
     sql = '''SELECT `incident`.`context`


### PR DESCRIPTION
- previously due to a typo "calim_all" would be incorrectly parsed as "claim last" `if claim_last or response.lower() == 'claim all'`
- previously when claiming multiple iris would return all the incident ids of recent messages, not just those that were claimed with a given command
- previously claim last would claim the most recent incident change the behaviour to claim the most recent active incident