### PR TITLE
Improve Docker-Compose Setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - "16649:16649"
     environment:
       - DOCKER_DB_BOOTSTRAP=1
-      - IRIS_CFG_DB_HOST=mysql
+      - IRIS_CFG_DB_HOST=iris-mysql
       - IRIS_CFG_DB_PASSWORD=1234
     volumes:
       - ./configs/config.dev.yaml:/home/iris/config/config.yaml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,8 @@ services:
       - ./configs/config.dev.yaml:/home/iris/config/config.yaml
 
   iris-mysql:
-    image: mysql:5.5
+    image: mysql:5.7
+    command: mysqld --sql_mode="STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"
     hostname: mysql
     environment:
       - MYSQL_ROOT_PASSWORD=1234


### PR DESCRIPTION
Update mysql in docker-compose setup to mysql 5.7 and making sure the correct sql modes are used.
Properly use the database connection hostname to make it compatible with podman-compose.