### PR TITLE
add sync-targets daemon

### DIFF
--- a/ops/daemons/uwsgi-docker.yaml
+++ b/ops/daemons/uwsgi-docker.yaml
@@ -42,5 +42,6 @@ prod:
     attach-daemon2:
       - cmd=/usr/sbin/nginx -c /home/iris/daemons/nginx.conf,pidfile=/home/iris/var/run/nginx.pid
       - cmd=/home/iris/env/bin/iris-sender /home/iris/config/config.yaml
+      - cmd=/home/iris/env/bin/iris-sync-targets /home/iris/config/config.yaml
 
 # vim:filetype=yaml

--- a/ops/daemons/uwsgi.yaml
+++ b/ops/daemons/uwsgi.yaml
@@ -42,5 +42,6 @@ prod:
     attach-daemon2:
       - cmd=/usr/sbin/nginx -c /home/iris/daemons/nginx.conf,pidfile=/home/iris/var/run/nginx.pid
       - cmd=/home/iris/env/bin/iris-sender /home/iris/config/config.yaml
+      - cmd=/home/iris/env/bin/iris-sync-targets /home/iris/config/config.yaml
 
 # vim:filetype=yaml


### PR DESCRIPTION
Environment deployment: Kubernetes
Deployment tools: Helm chart
User management: [Manual user administration](https://oncall.tools/docs/admin_guide.html#adding-users)

Issue:
Sync target from oncall user to iris need to trigger [manual command ](https://github.com/linkedin/iris/blob/master/docs/source/configuration.rst#oncall-integration)

Need to trigger automatically while adding user to [oncall](https://github.com/linkedin/oncall) platform since we are not using ldap for user management

I couldn’t see sync-target config for manual insertion, only for ldap, so i added sync-targets daemon process.

