### PR TITLE
send messages even if they fail to render

### DIFF
--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -6028,7 +6028,7 @@ class InternalBuildMessages():
                 message = render(message)
             except Exception as e:
                 logger.warning('Failed to render message %s with error: %s' % (ujson.dumps(notification), str(e)))
-            # send unrendered message even if we fail to render 
+            # send unrendered message even if we fail to render
             messages.append(message)
         if len(messages) == 0:
             raise HTTPBadRequest('Failed to build, could not resolve any messages from notification')

--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -6026,9 +6026,10 @@ class InternalBuildMessages():
                 continue
             try:
                 message = render(message)
-                messages.append(message)
             except Exception as e:
                 logger.warning('Failed to render message %s with error: %s' % (ujson.dumps(notification), str(e)))
+            # send unrendered message even if we fail to render 
+            messages.append(message)
         if len(messages) == 0:
             raise HTTPBadRequest('Failed to build, could not resolve any messages from notification')
 

--- a/src/iris/bin/sender.py
+++ b/src/iris/bin/sender.py
@@ -1010,7 +1010,7 @@ def render(message):
             # format define a generic template that will work for all contexts
             # - even those that are invalid as a final final format maybe repr or pprint
             logger.error(error, message)
-            message['subject'] = 'Iris failed to render your message' % message
+            message['subject'] = 'Iris failed to render your message'
             message['body'] = 'Failed rendering message.\n\nContext: %s\n\nError: %s' % (repr(message), error % message)
             message['template_id'] = None
         else:

--- a/src/iris/bin/sender.py
+++ b/src/iris/bin/sender.py
@@ -1010,13 +1010,13 @@ def render(message):
             # format define a generic template that will work for all contexts
             # - even those that are invalid as a final final format maybe repr or pprint
             logger.error(error, message)
-            message['subject'] = '%(message_id)s Iris failed to render your message' % message
+            message['subject'] = 'Iris failed to render your message' % message
             message['body'] = 'Failed rendering message.\n\nContext: %s\n\nError: %s' % (repr(message), error % message)
             message['template_id'] = None
         else:
             if config.get('enable_gmail_oneclick') and message['mode'] == 'email' and 'incident_id' in message:
                 oneclick_url = generate_oneclick_url(config, {
-                    'msg_id': message['message_id'],
+                    'msg_id': message.get('message_id'),
                     'email_address': message['destination'],
                     'cmd': 'claim'
                 })

--- a/src/iris/sender/cache.py
+++ b/src/iris/sender/cache.py
@@ -392,7 +392,7 @@ class TargetReprioritization(object):
         original_mode = message.get('mode')
 
         if not original_mode:
-            return
+            return message
 
         if seen is None:
             seen = set([original_mode])
@@ -400,7 +400,7 @@ class TargetReprioritization(object):
             if original_mode in seen:
                 logger.info('target reprioritization loop detected for %s, %s: %r',
                             message['target'], original_mode, seen)
-                return
+                return message
             else:
                 seen.add(original_mode)
         try:
@@ -425,6 +425,7 @@ class TargetReprioritization(object):
             # target has no reprioritization rules defined
             # leave existing mode
             return message
+        return message
 
 
 class RoleTargets():


### PR DESCRIPTION
- fix bugs where messages that fail to render would return a 400 to the external sender instead of the unrendered message
- fix bug where message reprioritization would cause message to fail to render