### PR TITLE
set auto_parse_qs_csv to True

### DIFF
--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -6544,6 +6544,8 @@ def construct_falcon_api(debug, healthcheck_path, allowed_origins, iris_sender_a
 
     api.set_error_serializer(json_error_serializer)
     api.req_options.strip_url_path_trailing_slash = True
+    # needed to preserve get_param_as_list behavior
+    api.req_options.auto_parse_qs_csv = True
 
     api.add_route('/v0/plans/{plan_id}', Plan())
     api.add_route('/v0/plans', Plans())


### PR DESCRIPTION
in order to to preserve get_param_as_list behaviorset auto_parse_qs_csv to True. Otherwise requests with comma delimited param lists will fail