### PR TITLE
fix users readded oncall-sync bug

### DIFF
--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -6544,6 +6544,8 @@ def construct_falcon_api(debug, healthcheck_path, allowed_origins, iris_sender_a
 
     api.set_error_serializer(json_error_serializer)
     api.req_options.strip_url_path_trailing_slash = True
+    # needed to preserve get_param_as_list behavior
+    api.req_options.auto_parse_qs_csv = True
 
     api.add_route('/v0/plans/{plan_id}', Plan())
     api.add_route('/v0/plans', Plans())

--- a/src/iris/bin/sync_targets.py
+++ b/src/iris/bin/sync_targets.py
@@ -236,7 +236,7 @@ def sync_from_oncall(config, engine, purge_old_users=True):
     oncall_add_sql = 'INSERT INTO `oncall_team` (`target_id`, `oncall_team_id`) VALUES (%s, %s)'
     user_add_sql = 'INSERT IGNORE INTO `user` (`target_id`) VALUES (%s)'
     target_contact_add_sql = '''INSERT INTO `target_contact` (`target_id`, `mode_id`, `destination`)
-                                VALUES (%s, %s, %s)
+                                VALUES ((SELECT `id` FROM `target` WHERE `name`=%s AND `type_id`=%s LIMIT 1), %s, %s)
                                 ON DUPLICATE KEY UPDATE `destination` = %s'''
 
     # insert users that need to be
@@ -257,7 +257,7 @@ def sync_from_oncall(config, engine, purge_old_users=True):
             if value and key in modes:
                 logger.info('%s: %s -> %s', username, key, value)
                 try:
-                    engine.execute(target_contact_add_sql, (target_id, modes[key], value, value))
+                    engine.execute(target_contact_add_sql, (username, target_types['user'], modes[key], value, value))
                 except SQLAlchemyError as e:
                     logger.exception('Error adding contact for target id: %s', target_id)
                     metrics.incr('sql_errors')


### PR DESCRIPTION
under current behavior if a user is deactivated and later rejoins it will cause an sql error as target id set in line 284 `target_id = engine.execute(target_add_sql, (username, target_types['user'])).lastrowid` will be 0 and the subsequent updating of target contact will fail. Fix this by getting the target id for the contact insert from a subselect instead.