### PR TITLE
Change validation requirements for grafana endpoint

### DIFF
--- a/src/iris/webhooks/grafana.py
+++ b/src/iris/webhooks/grafana.py
@@ -14,11 +14,6 @@ logger = logging.getLogger(__name__)
 class grafana(webhook):
     allow_read_no_auth = False
 
-    def validate_post(self, body):
-        if not all(k in body for k in ("ruleName", "state")):
-            logger.warning('missing ruleName and/or state attributes')
-            raise HTTPBadRequest('missing ruleName and/of state attributes')
-
     def create_context(self, body):
         context_json_str = ujson.dumps(body)
         if len(context_json_str) > 65535:
@@ -37,7 +32,6 @@ class grafana(webhook):
         Url: http://iris:16649/v0/webhooks/grafana?application=test-app&key=sdffdssdf&plan=team1
         '''
         alert_params = ujson.loads(req.context['body'])
-        self.validate_post(alert_params)
 
         with db.guarded_session() as session:
             plan = req.get_param('plan', True)

--- a/test/test_webhook_grafana.py
+++ b/test/test_webhook_grafana.py
@@ -2,7 +2,6 @@
 # See LICENSE in the project root for license information.
 
 import pytest
-import ujson
 from falcon import HTTPBadRequest
 
 

--- a/test/test_webhook_grafana.py
+++ b/test/test_webhook_grafana.py
@@ -28,8 +28,7 @@ def test_parse_valid_body():
         "state": "alerting",
         "title": "[Alerting] Test notification"
     }
-    alert_params = ujson.loads(fake_post)
-    grafana_webhook.create_context(alert_params)
+    grafana_webhook.create_context(fake_post)
 
 
 def test_parse_invalid_body():
@@ -56,5 +55,4 @@ def test_parse_invalid_body():
     }
 
     with pytest.raises(HTTPBadRequest):
-        alert_params = ujson.loads(fake_post)
-        grafana_webhook.create_context(alert_params)
+        grafana_webhook.create_context(fake_post)

--- a/test/test_webhook_grafana.py
+++ b/test/test_webhook_grafana.py
@@ -2,6 +2,7 @@
 # See LICENSE in the project root for license information.
 
 import pytest
+import ujson
 from falcon import HTTPBadRequest
 
 
@@ -27,7 +28,8 @@ def test_parse_valid_body():
         "state": "alerting",
         "title": "[Alerting] Test notification"
     }
-    grafana_webhook.validate_post(fake_post)
+    alert_params = ujson.loads(fake_post)
+    grafana_webhook.create_context(alert_params)
 
 
 def test_parse_invalid_body():
@@ -47,10 +49,12 @@ def test_parse_invalid_body():
         "imageUrl": "http://grafana.org/assets/img/blog/mixed_styles.png",
         "message": "Someone is testing the alert notification within grafana.",
         "ruleId": 0,
+        "longTextVal": 7000 * "very very long text",
         "ruleName": "Test notification",
         "ruleUrl": "https://grafana.org/",
         "title": "[Alerting] Test notification"
     }
 
     with pytest.raises(HTTPBadRequest):
-        grafana_webhook.validate_post(fake_post)
+        alert_params = ujson.loads(fake_post)
+        grafana_webhook.create_context(alert_params)


### PR DESCRIPTION
- remove validate post as newer versions of grafana will not have those parameters and they are not directly referenced within the iris code 