### PR TITLE
[DB SCHEMA CHANGE] Dynamic tracking notifications

### DIFF
--- a/db/dummy_data.sql
+++ b/db/dummy_data.sql
@@ -63,6 +63,9 @@ UNLOCK TABLES;
 LOCK TABLES `dynamic_plan_map` WRITE;
 UNLOCK TABLES;
 
+LOCK TABLES `dynamic_tracking_notification` WRITE;
+UNLOCK TABLES;
+
 LOCK TABLES `generic_message_sent_status` WRITE;
 UNLOCK TABLES;
 
@@ -94,21 +97,21 @@ UNLOCK TABLES;
 
 LOCK TABLES `plan` WRITE;
 INSERT INTO `plan` VALUES
-    (1,'demo-test-foo','2017-01-25 23:23:55',1,NULL,'Test plan for e2e test',2,900,10,300,300,NULL,NULL,NULL),
-    (7,'demo-test-incident-post','2017-01-25 23:23:55',1,NULL,'Test plan for e2e test',1,900,10,300,300,NULL,NULL,NULL),
-    (8,'demo-test-incident-post','2017-01-25 23:23:56',1,NULL,'Test plan for e2e test',1,900,10,300,300,NULL,NULL,NULL),
-    (11,'demo-test-foo','2017-01-25 23:25:46',1,NULL,'Test plan for e2e test',2,900,10,300,300,NULL,NULL,NULL),
-    (17,'demo-test-incident-post','2017-01-25 23:25:46',1,NULL,'Test plan for e2e test',1,900,10,300,300,NULL,NULL,NULL),
-    (18,'demo-test-incident-post','2017-01-25 23:25:46',1,NULL,'Test plan for e2e test',1,900,10,300,300,NULL,NULL,NULL),
-    (21,'demo-test-foo','2017-01-25 23:26:44',1,NULL,'Test plan for e2e test',2,900,10,300,300,NULL,NULL,NULL),
-    (27,'demo-test-incident-post','2017-01-25 23:26:44',1,NULL,'Test plan for e2e test',1,900,10,300,300,NULL,NULL,NULL),
-    (28,'demo-test-incident-post','2017-01-25 23:26:45',1,NULL,'Test plan for e2e test',1,900,10,300,300,NULL,NULL,NULL),
-    (31,'demo-test-foo','2017-01-25 23:30:34',1,NULL,'Test plan for e2e test',2,900,10,300,300,NULL,NULL,NULL),
-    (37,'demo-test-incident-post','2017-01-25 23:30:34',1,NULL,'Test plan for e2e test',1,900,10,300,300,NULL,NULL,NULL),
-    (38,'demo-test-incident-post','2017-01-25 23:30:34',1,NULL,'Test plan for e2e test',1,900,10,300,300,NULL,NULL,NULL),
-    (39,'demo-test-other-app-incident-post','2017-01-25 23:30:34',1,NULL,'Test plan for e2e test',1,900,10,300,300,NULL,NULL,NULL),
-    (40,'demo-test-bar','2017-01-25 23:25:46',1,NULL,'Test plan for e2e email incident test',1,900,10,300,300,NULL,NULL,NULL),
-    (41,'Oncall test','2018-01-26 22:32:04',1,NULL,'Test plan for Oncall Iris integration',1,900,10,300,300,NULL,NULL,NULL);
+    (1,'demo-test-foo','2017-01-25 23:23:55',1,NULL,'Test plan for e2e test',2,900,10,300,300,NULL,NULL,NULL,0),
+    (7,'demo-test-incident-post','2017-01-25 23:23:55',1,NULL,'Test plan for e2e test',1,900,10,300,300,NULL,NULL,NULL,0),
+    (8,'demo-test-incident-post','2017-01-25 23:23:56',1,NULL,'Test plan for e2e test',1,900,10,300,300,NULL,NULL,NULL,0),
+    (11,'demo-test-foo','2017-01-25 23:25:46',1,NULL,'Test plan for e2e test',2,900,10,300,300,NULL,NULL,NULL,0),
+    (17,'demo-test-incident-post','2017-01-25 23:25:46',1,NULL,'Test plan for e2e test',1,900,10,300,300,NULL,NULL,NULL,0),
+    (18,'demo-test-incident-post','2017-01-25 23:25:46',1,NULL,'Test plan for e2e test',1,900,10,300,300,NULL,NULL,NULL,0),
+    (21,'demo-test-foo','2017-01-25 23:26:44',1,NULL,'Test plan for e2e test',2,900,10,300,300,NULL,NULL,NULL,0),
+    (27,'demo-test-incident-post','2017-01-25 23:26:44',1,NULL,'Test plan for e2e test',1,900,10,300,300,NULL,NULL,NULL,0),
+    (28,'demo-test-incident-post','2017-01-25 23:26:45',1,NULL,'Test plan for e2e test',1,900,10,300,300,NULL,NULL,NULL,0),
+    (31,'demo-test-foo','2017-01-25 23:30:34',1,NULL,'Test plan for e2e test',2,900,10,300,300,NULL,NULL,NULL,0),
+    (37,'demo-test-incident-post','2017-01-25 23:30:34',1,NULL,'Test plan for e2e test',1,900,10,300,300,NULL,NULL,NULL,0),
+    (38,'demo-test-incident-post','2017-01-25 23:30:34',1,NULL,'Test plan for e2e test',1,900,10,300,300,NULL,NULL,NULL,0),
+    (39,'demo-test-other-app-incident-post','2017-01-25 23:30:34',1,NULL,'Test plan for e2e test',1,900,10,300,300,NULL,NULL,NULL,0),
+    (40,'demo-test-bar','2017-01-25 23:25:46',1,NULL,'Test plan for e2e email incident test',1,900,10,300,300,NULL,NULL,NULL,0),
+    (41,'Oncall test','2018-01-26 22:32:04',1,NULL,'Test plan for Oncall Iris integration',1,900,10,300,300,NULL,NULL,NULL,0);
 UNLOCK TABLES;
 
 LOCK TABLES `plan_active` WRITE;

--- a/db/schema_0.sql
+++ b/db/schema_0.sql
@@ -164,6 +164,7 @@ CREATE TABLE `plan` (
   `tracking_key` varchar(255) DEFAULT NULL,
   `tracking_type` varchar(255) DEFAULT NULL,
   `tracking_template` text,
+  `dynamic_tracking` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   KEY `user_id` (`user_id`),
   KEY `team_id` (`team_id`),
@@ -241,6 +242,28 @@ CREATE TABLE `dynamic_plan_map` (
   CONSTRAINT `dynamic_plan_map_ibfk_3` FOREIGN KEY (`incident_id`) REFERENCES `incident` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
+
+
+--
+-- Table structure for table `dynamic_tracking_notification`
+--
+
+DROP TABLE IF EXISTS `dynamic_tracking_notification`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `dynamic_tracking_notification` (
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `incident_id` bigint(20) NOT NULL,
+  `application_id` int(11) NOT NULL,
+  `destination` varchar(255) NOT NULL,
+  `mode_id` int(11) NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `ix_dynamic_tracking_notification_incident_id` (`incident_id`),
+  KEY `ix_dynamic_tracking_notification_application_id` (`application_id`),
+  KEY `ix_dynamic_tracking_notification_mode_id` (`mode_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
 
 --
 -- Table structure for table `priority`

--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -7211,7 +7211,6 @@ class InternalIncidents():
         cursor = connection.cursor(db.dict_cursor)
         cursor.execute('''SELECT `id` FROM `incident` WHERE `active` = 1 AND `bucket_id` IN (SELECT `bucket_id` FROM `IMP_bucket_assignments` WHERE `node_id` = %s)''', node_id)
         result = cursor.fetchall()
-        print(node_id, result)
         cursor.close()
         connection.close()
         incident_ids = [row["id"] for row in result]

--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -1187,6 +1187,7 @@ class Plan(object):
 
             cursor.execute(single_plan_query_tags, plan['id'])
             plan['tags'] = cursor.fetchall()
+            plan['dynamic_tracking'] = bool(plan.get('dynamic_tracking'))
 
             resp.body = ujson.dumps(plan)
             connection.close()
@@ -1444,6 +1445,7 @@ class Plans(object):
                     plan['tags'] = []
                 else:
                     plan['tags'] = ujson.loads(plan['tags'])
+            plan['dynamic_tracking'] = bool(plan.get('dynamic_tracking'))
             results.append(plan)
 
         if counts_only:

--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -240,7 +240,7 @@ WHERE `comment`.`incident_id` = %s
 
 single_incident_query_tags = '''SELECT `name`, `value` from `incident_metadata_tag` where `incident_metadata_tag`.`incident_id` = %s'''
 
-incident_dynamic_tracking_notifications_query = '''SELECT `application_id`, `application`.`name` as application, `destination`, `mode_id`, `mode`.`name` as mode
+incident_dynamic_tracking_notifications_query = '''SELECT `incident_id`, `application_id`, `application`.`name` as application, `destination`, `mode_id`, `mode`.`name` as mode
         FROM `dynamic_tracking_notification` JOIN `application` ON `application`.`id` = `dynamic_tracking_notification`.`application_id`
         JOIN `mode` ON `mode`.`id` = `dynamic_tracking_notification`.`mode_id`
         WHERE `dynamic_tracking_notification`.`incident_id` IN %s'''

--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -7201,11 +7201,11 @@ class InternalIncidents():
 
     def on_get(self, req, resp, node_id):
 
-        # if not (self.external_sender_incident_processing or self.external_sender_incident_dryrun):
-        #     # do not return any incidents
-        #     resp.status = HTTP_200
-        #     resp.body = ujson.dumps([])
-        #     return
+        if not (self.external_sender_incident_processing or self.external_sender_incident_dryrun):
+            # do not return any incidents
+            resp.status = HTTP_200
+            resp.body = ujson.dumps([])
+            return
 
         connection = db.engine.raw_connection()
         cursor = connection.cursor(db.dict_cursor)

--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -240,6 +240,11 @@ WHERE `comment`.`incident_id` = %s
 
 single_incident_query_tags = '''SELECT `name`, `value` from `incident_metadata_tag` where `incident_metadata_tag`.`incident_id` = %s'''
 
+incident_dynamic_tracking_notifications_query = '''SELECT `application_id`, `application`.`name` as application, `destination`, `mode_id`, `mode`.`name` as mode
+        FROM `dynamic_tracking_notification` JOIN `application` ON `application`.`id` = `dynamic_tracking_notification`.`application_id`
+        JOIN `mode` ON `mode`.`id` = `dynamic_tracking_notification`.`mode_id`
+        WHERE `dynamic_tracking_notification`.`incident_id` IN %s'''
+
 plan_columns = {
     'id': '`plan`.`id` as `id`',
     'name': '`plan`.`name` as `name`',
@@ -250,6 +255,7 @@ plan_columns = {
     'tracking_type': '`plan`.`tracking_type` as `tracking_type`',
     'tracking_key': '`plan`.`tracking_key` as `tracking_key`',
     'tracking_template': '`plan`.`tracking_template` as `tracking_template`',
+    'dynamic_tracking': '`plan`.`dynamic_tracking` as `dynamic_tracking`',
     'description': '`plan`.`description` as `description`',
     'created': 'UNIX_TIMESTAMP(`plan`.`created`) as `created`',
     'creator': '`target`.`name` as `creator`',
@@ -302,7 +308,8 @@ single_plan_query = '''SELECT `plan`.`id` as `id`, `plan`.`name` as `name`,
     `plan`.`description` as `description`, UNIX_TIMESTAMP(`plan`.`created`) as `created`,
     `target`.`name` as `creator`, IF(`plan_active`.`plan_id` IS NULL, FALSE, TRUE) as `active`,
     `plan`.`tracking_type` as `tracking_type`, `plan`.`tracking_key` as `tracking_key`,
-    `plan`.`tracking_template` as `tracking_template`
+    `plan`.`tracking_template` as `tracking_template`,
+    `plan`.`dynamic_tracking` as `dynamic_tracking`
 FROM `plan` JOIN `target` ON `plan`.`user_id` = `target`.`id`
 LEFT OUTER JOIN `plan_active` ON `plan`.`id` = `plan_active`.`plan_id`'''
 
@@ -378,7 +385,7 @@ single_template_query_tags = '''SELECT `name`, `value` from `template_metadata_t
 insert_plan_query = '''INSERT INTO `plan` (
     `user_id`, `name`, `created`, `description`, `step_count`,
     `threshold_window`, `threshold_count`, `aggregation_window`,
-    `aggregation_reset`, `tracking_key`, `tracking_type`, `tracking_template`
+    `aggregation_reset`, `tracking_key`, `tracking_type`, `tracking_template`, `dynamic_tracking`
 ) VALUES (
     (SELECT `id` FROM `target` where `name` = :creator AND `type_id` = (
       SELECT `id` FROM `target_type` WHERE `name` = 'user'
@@ -393,7 +400,8 @@ insert_plan_query = '''INSERT INTO `plan` (
     :aggregation_reset,
     :tracking_key,
     :tracking_type,
-    :tracking_template
+    :tracking_template,
+    :dynamic_tracking
 )'''
 
 insert_plan_step_query = '''INSERT INTO `plan_notification` (
@@ -1313,6 +1321,7 @@ class Plans(object):
                      "tracking_type": null,
                      "tracking_template": null,
                      "tracking_key": null,
+                     "dynamic_tracking": 1,
                      "active": 1,
                      "id": 123456,
                      "name": "foo-sla0"
@@ -1560,7 +1569,10 @@ class Plans(object):
         The total time of all plan steps can not exceed 24 hours.
 
         '''
-        plan_params = ujson.loads(req.context['body'])
+        try:
+            plan_params = ujson.loads(req.context['body'])
+        except ValueError:
+            raise falcon.HTTPBadRequest('Invalid JSON', 'Could not parse the request body as JSON.')
         try:
             run_validation('plan', plan_params)
         except IrisValidationException as e:
@@ -1591,6 +1603,7 @@ class Plans(object):
         tracking_key = plan_params.get('tracking_key')
         tracking_type = plan_params.get('tracking_type')
         tracking_template = plan_params.get('tracking_template')
+        dynamic_tracking = 1 if plan_params.get('dynamic_tracking') else 0
         is_valid, err_msg = is_valid_tracking_settings(tracking_type, tracking_key, tracking_template)
         if not is_valid:
             raise HTTPBadRequest('Invalid tracking template', err_msg)
@@ -1614,6 +1627,7 @@ class Plans(object):
             'tracking_key': tracking_key,
             'tracking_type': tracking_type,
             'tracking_template': tracking_template,
+            'dynamic_tracking': dynamic_tracking
         }
 
         dynamic_indices = set()
@@ -1999,13 +2013,54 @@ class Incidents(object):
             ]
 
         This will map target 0 to the user "jdoe", and target 1 to the team "team-foo".
-        '''
-        incident_params = ujson.loads(req.context['body'])
-        dynamic_targets = []
-        if 'plan' not in incident_params:
-            raise HTTPBadRequest('missing plan name attribute')
 
-        app = req.context['app']
+        To use dynamic tracking you can pass a dynamic_tracking_notifications list in the incident_params. If the plan has dynamic tracking enabled, the incident will be created with the dynamic tracking notifications specified in the incident_params. The tracking message will use the tracking template specified in the plan.
+
+        .. sourcecode:: json
+
+        "dynamic_tracking_notifications": [{"mode": "slack", "destination": "#iris-slack-testing"}, {"mode": "slack", "destination": "#iris-slack-testing2"}]
+        '''
+        try:
+            incident_params = ujson.loads(req.context["body"])
+        except ValueError:
+            raise falcon.HTTPBadRequest(
+                "Invalid JSON", "Could not parse the request body as JSON."
+            )
+        dynamic_targets = []
+        if "plan" not in incident_params:
+            raise HTTPBadRequest("missing plan name attribute")
+
+        app = req.context["app"]
+
+        dynamic_tracking_notifications = incident_params.get(
+            "dynamic_tracking_notifications", []
+        )
+        if not isinstance(dynamic_tracking_notifications, list):
+            raise falcon.HTTPBadRequest(
+                "Invalid Format", "dynamic_tracking_notifications should be a list."
+            )
+        for notification in dynamic_tracking_notifications:
+            if not isinstance(notification, dict):
+                raise falcon.HTTPBadRequest(
+                    "Invalid Format", "Each notification should be a dictionary."
+                )
+            if "mode" not in notification or not isinstance(notification["mode"], str):
+                raise falcon.HTTPBadRequest(
+                    "Invalid Format", "Each notification should have a string mode."
+                )
+            if "destination" not in notification or not isinstance(
+                notification["destination"], str
+            ):
+                raise falcon.HTTPBadRequest(
+                    "Invalid Format",
+                    "Each notification should have a string destination.",
+                )
+            if len(notification["destination"]) >= 255:
+                raise falcon.HTTPBadRequest(
+                    "Invalid Format",
+                    "Each notification destination should be less than 255 characters.",
+                )
+        mode_ids = {}
 
         with db.guarded_session() as session:
             plan_id = session.execute('SELECT `plan_id` FROM `plan_active` WHERE `name` = :plan',
@@ -2016,6 +2071,18 @@ class Incidents(object):
             num_dynamic = session.execute('SELECT COUNT(DISTINCT `dynamic_index`) FROM `plan_notification` '
                                           'WHERE `plan_id` = :plan_id',
                                           {'plan_id': plan_id}).scalar()
+
+            if len(dynamic_tracking_notifications) > 0:
+                # check if plan has dynamic_tracking enabled
+                dynamic_tracking_plan = session.execute('''
+                    SELECT EXISTS (
+                    SELECT 1 FROM `plan`WHERE `id` = :plan_id
+                    AND `dynamic_tracking` = 1
+                    )
+                ''', {'plan_id': plan_id}).scalar()
+
+                if not dynamic_tracking_plan:
+                    raise HTTPBadRequest('Invalid plan for dynamic tracking', 'Plan does not have dynamic tracking enabled')
 
             # Support overriding the app which created this incident
             if 'application' in incident_params:
@@ -2076,6 +2143,13 @@ class Incidents(object):
             if not app_template_count:
                 raise HTTPBadRequest('No plan template actions exist for this app')
 
+            if len(dynamic_tracking_notifications) > 0:
+                mode_results = session.execute('SELECT `id`, `name` FROM `mode`')
+                mode_ids = {row['name']: row['id'] for row in mode_results}
+                for notification in dynamic_tracking_notifications:
+                    if notification['mode'] not in mode_ids:
+                        raise HTTPBadRequest('invalid mode %s specified for dynamic_tracking_notifications' % notification['mode'])
+
         # To try to avoid deadlocks, split the inserts into their own session
         retries = 0
         max_retries = 10
@@ -2110,6 +2184,20 @@ class Incidents(object):
                                                                            `target_id`, `dynamic_index`)
                                            VALUES (:incident_id, :role_id, :target_id, :index)''',
                                         data)
+
+                    for notification in dynamic_tracking_notifications:
+                        mode_id = mode_ids[notification['mode']]
+                        data = {
+                            'incident_id': incident_id,
+                            'application_id': app['id'],
+                            'destination': notification['destination'],
+                            'mode_id': mode_id
+                        }
+
+                        session.execute(
+                            """ INSERT INTO dynamic_tracking_notification (incident_id, application_id, destination, mode_id) VALUES (:incident_id, :application_id, :destination, :mode_id)""",
+                            data,
+                        )
 
                     session.commit()
                     session.close()
@@ -2269,9 +2357,17 @@ class Incident(object):
 
             cursor.execute(single_incident_query_tags, incident['id'])
             incident['tags'] = cursor.fetchall()
-            connection.close()
 
             incident['context'] = ujson.loads(incident['context'])
+            # retrieve dynamic_tracking_notification for each incident
+            incident['dynamic_tracking'] = []
+            cursor.execute(incident_dynamic_tracking_notifications_query, [(incident_id,)])
+            dynamic_tracking_results = cursor.fetchall()
+            if dynamic_tracking_results:
+                for tracking in dynamic_tracking_results:
+                    incident['dynamic_tracking'].append(tracking)
+
+            connection.close()
             payload = ujson.dumps(incident)
         else:
             connection.close()
@@ -7119,8 +7215,10 @@ class InternalIncidents():
         resp.body = ujson.dumps(incident_ids)
 
     def on_post(self, req, resp, node_id):
-
-        body = ujson.loads(req.context['body'])
+        try:
+            body = ujson.loads(req.context['body'])
+        except ValueError:
+            raise falcon.HTTPBadRequest('Invalid JSON', 'Could not parse the request body as JSON.')
 
         if 'incident_ids' not in body:
             raise HTTPBadRequest('Missing incident ids in POST body')
@@ -7131,14 +7229,28 @@ class InternalIncidents():
         if len(body['incident_ids']) < 1:
             raise HTTPBadRequest('incident_ids list cannot be empty')
 
-        query = incident_query % ', '.join(incident_columns[f] for f in incident_columns)
-        query += ' WHERE `incident`.`active` = 1 AND `incident`.`id` IN %s'
         sql_values = [tuple(body['incident_ids'])]
         connection = db.engine.raw_connection()
         cursor = connection.cursor(db.ss_dict_cursor)
+        # retrieve dynamic_tracking_notification for each incident
+        cursor.execute(incident_dynamic_tracking_notifications_query, sql_values)
+        dynamic_tracking_results = cursor.fetchall()
+
+        # retrieve incidents
+        query = incident_query % ', '.join(incident_columns[f] for f in incident_columns)
+        query += ' WHERE `incident`.`active` = 1 AND `incident`.`id` IN %s'
         cursor.execute(query, sql_values)
+        results = []
+        for incident in cursor:
+            incident['context'] = ujson.loads(incident['context'])
+            incident['dynamic_tracking'] = []
+            if dynamic_tracking_results:
+                for tracking in dynamic_tracking_results:
+                    if incident['id'] == tracking.get('incident_id'):
+                        incident['dynamic_tracking'].append(tracking)
+            results.append(incident)
         resp.status = HTTP_200
-        resp.body = ujson.dumps(stream_incidents_with_context(cursor, False))
+        resp.body = ujson.dumps(results)
         cursor.close()
         connection.close()
 

--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -1187,7 +1187,7 @@ class Plan(object):
 
             cursor.execute(single_plan_query_tags, plan['id'])
             plan['tags'] = cursor.fetchall()
-            plan['dynamic_tracking'] = bool(plan.get('dynamic_tracking'))
+            plan['dynamic_tracking'] = bool(plan['dynamic_tracking'])
 
             resp.body = ujson.dumps(plan)
             connection.close()
@@ -2363,12 +2363,8 @@ class Incident(object):
 
             incident['context'] = ujson.loads(incident['context'])
             # retrieve dynamic_tracking_notification for each incident
-            incident['dynamic_tracking'] = []
             cursor.execute(incident_dynamic_tracking_notifications_query, [(incident_id,)])
-            dynamic_tracking_results = cursor.fetchall()
-            if dynamic_tracking_results:
-                for tracking in dynamic_tracking_results:
-                    incident['dynamic_tracking'].append(tracking)
+            incident['dynamic_tracking'] = cursor.fetchall()
 
             connection.close()
             payload = ujson.dumps(incident)

--- a/src/iris/api.py
+++ b/src/iris/api.py
@@ -1445,7 +1445,8 @@ class Plans(object):
                     plan['tags'] = []
                 else:
                     plan['tags'] = ujson.loads(plan['tags'])
-            plan['dynamic_tracking'] = bool(plan.get('dynamic_tracking'))
+            if 'dynamic_tracking' in plan:
+                plan['dynamic_tracking'] = bool(plan.get('dynamic_tracking'))
             results.append(plan)
 
         if counts_only:
@@ -7200,16 +7201,17 @@ class InternalIncidents():
 
     def on_get(self, req, resp, node_id):
 
-        if not (self.external_sender_incident_processing or self.external_sender_incident_dryrun):
-            # do not return any incidents
-            resp.status = HTTP_200
-            resp.body = ujson.dumps([])
-            return
+        # if not (self.external_sender_incident_processing or self.external_sender_incident_dryrun):
+        #     # do not return any incidents
+        #     resp.status = HTTP_200
+        #     resp.body = ujson.dumps([])
+        #     return
 
         connection = db.engine.raw_connection()
         cursor = connection.cursor(db.dict_cursor)
         cursor.execute('''SELECT `id` FROM `incident` WHERE `active` = 1 AND `bucket_id` IN (SELECT `bucket_id` FROM `IMP_bucket_assignments` WHERE `node_id` = %s)''', node_id)
         result = cursor.fetchall()
+        print(node_id, result)
         cursor.close()
         connection.close()
         incident_ids = [row["id"] for row in result]

--- a/src/iris/bin/retention.py
+++ b/src/iris/bin/retention.py
@@ -274,6 +274,27 @@ def process_retention(engine, max_days, batch_size, cooldown_time, archive_path)
                 else:
                     break
 
+        # Kill all dynamic tracking notifications associated with these incidents
+        while True:
+            try:
+                deleted_rows = cursor.execute('DELETE FROM `dynamic_tracking_notification` WHERE `incident_id` IN %s', [tuple(incident_ids)])
+                connection.commit()
+            except Exception:
+                metrics.incr('sql_errors')
+                logger.exception('Failed deleting dynamic tracking notifications')
+                try:
+                    cursor.close()
+                except Exception:
+                    pass
+                cursor = connection.cursor(engine.dialect.dbapi.cursors.SSCursor)
+                break
+            else:
+                if deleted_rows:
+                    logger.info('Killed %d dynamic tracking notifications', deleted_rows)
+                    sleep(cooldown_time)
+                else:
+                    break
+
         # Kill all metadata
         while True:
             try:

--- a/src/iris/ui/static/js/iris.js
+++ b/src/iris/ui/static/js/iris.js
@@ -156,6 +156,7 @@ iris = {
       aggregationBtn: '#aggregation h4',
       trackingType: '#tracking-type',
       trackingKey: '#tracking-key',
+      dynamicTracking: '#dynamic-tracking',
       trackingTemplateBtn: '#tracking-notification[data-view="false"] .tracking-inner h4',
       variablesTemplateSource: $('#variables-template').html(),
       appSelect: '.template-application',
@@ -638,6 +639,12 @@ iris = {
 
         model.tracking_type = $trackingEl.find('#tracking-type').val();
         model.tracking_key = $trackingEl.find('#tracking-key').val();
+
+        if ($trackingEl.find('#dynamic-tracking').val() == "true"){
+          model.dynamic_tracking = true;
+        } else {
+          model.dynamic_tracking = false;
+        }
 
         if (!model.tracking_key) {
           $trackingEl.find('#tracking-key').addClass('invalid-input');

--- a/src/iris/ui/templates/plan.html
+++ b/src/iris/ui/templates/plan.html
@@ -201,6 +201,13 @@
             <label data-toggle="tooltip" title="Target key for the tracking message" class="required">Target:</label>
             <input type="text" id="tracking-key" class="form-control border-bottom" data-default="true" value="{{ tracking_key }}" placeholder="example@example.com">
           </span>
+          <span class="item-content" title="Dynamic tracking"></span>
+            <label data-toggle="tooltip" title="Enabling Dynamic Tracking will override the target of the tracking notification with the destinations passed at incident creation time in the 'dynamic_tracking_notification' field">Dynamic tracking:</label>
+            <select id="dynamic-tracking" class="form-control border-bottom">
+              <option value="false" {{#unless dynamic_tracking}}selected{{/unless}}>disabled</option>
+              <option value="true" {{#if dynamic_tracking}}selected{{/if}}>enabled</option>
+            </select>
+          </div>
         </div>
         <ul class="template-steps">
           {{>plan-tracking-notification}}

--- a/test/e2etest.py
+++ b/test/e2etest.py
@@ -1485,7 +1485,8 @@ def test_post_dynamic_incident(sample_user, sample_team, sample_application_name
                 },
             ],
         ],
-        "isValid": True
+        "isValid": True,
+        "dynamic_tracking": True
     }
     re = requests.post(base_url + 'plans', json=data, headers=username_header(sample_user))
     assert re.status_code == 201
@@ -1495,12 +1496,52 @@ def test_post_dynamic_incident(sample_user, sample_team, sample_application_name
         'plan': sample_user + '-test-incident-dynamic-post',
         'context': {},
         'dynamic_targets': [{'role': 'user', 'target': sample_user},
-                            {'role': 'team', 'target': sample_team}]
+                            {'role': 'team', 'target': sample_team}],
+        "dynamic_tracking_notifications": [{"mode": "slack", "destination": "#iris-slack-testing"}]
     }, headers={'Authorization': 'hmac %s:abc' % sample_application_name})
     incident_id = int(re.content)
     assert re.status_code == 201
     re = requests.get(base_url + 'incidents/%s' % incident_id)
     assert re.status_code == 200
+
+    incident_data = {
+        'plan_id': 55,
+        'plan': 'demo-test-incident-dynamic-post',
+        'updated': None,
+        'context': {
+            'fabric': None,
+            'console_url': None,
+            'filename': None,
+            'name': None,
+            'graph_image_url': None,
+            'zones': None,
+            'nodes': None,
+            'metanodes': None,
+            'notes': None
+        },
+        'owner': None,
+        'application': 'Autoalerts',
+        'current_step': 0,
+        'active': 1,
+        'resolved': 0,
+        'steps': [],
+        'comments': [],
+        'tags': [],
+        'dynamic_tracking': [
+            {
+                'application_id': 8,
+                'application': 'Autoalerts',
+                'destination': '#iris-slack-testing',
+                'mode_id': 17,
+                'mode': 'slack'
+            }
+        ]
+    }
+
+    incident_response = re.json()
+    incident_response.pop('created')
+    incident_response.pop('id')
+    assert incident_response == incident_data
 
     # Claim
     re = requests.post(base_url + 'incidents/%d' % (incident_id, ), json={
@@ -3475,6 +3516,16 @@ def test_get_allowed_tags(superuser_application):
         ]
     }
     assert response == expected
+
+
+def test_dynamic_tracking_notification_fail(sample_plan_name, sample_application_name):
+
+    # create an incident with dynamic tracking notification agaings a plan that doesn't have them enabled
+    re = requests.post(base_url + 'incidents',
+                       json={"plan": sample_plan_name, "context": {}, "dynamic_tracking_notifications": [{"mode": "slack", "destination": "#iris-slack-testing"}]},
+                       headers={'Authorization': 'hmac %s:abc' % sample_application_name})
+    assert re.status_code == 400
+    assert re.json()['title'] == 'Invalid plan for dynamic tracking'
 
 
 def test_create_incident_by_email(sample_application_name, sample_plan_name, sample_plan_name2, sample_admin_user):

--- a/test/e2etest.py
+++ b/test/e2etest.py
@@ -1505,7 +1505,6 @@ def test_post_dynamic_incident(sample_user, sample_team, sample_application_name
     assert re.status_code == 200
 
     incident_data = {
-        'plan_id': 55,
         'plan': 'demo-test-incident-dynamic-post',
         'updated': None,
         'context': {
@@ -1539,6 +1538,7 @@ def test_post_dynamic_incident(sample_user, sample_team, sample_application_name
     }
 
     incident_response = re.json()
+    incident_response.pop('plan_id')
     incident_response.pop('created')
     incident_response.pop('id')
     for notification in incident_response['dynamic_tracking']:

--- a/test/e2etest.py
+++ b/test/e2etest.py
@@ -1541,6 +1541,7 @@ def test_post_dynamic_incident(sample_user, sample_team, sample_application_name
     incident_response = re.json()
     incident_response.pop('created')
     incident_response.pop('id')
+    incident_response['dynamic_tracking'].pop('incident_id')
     assert incident_response == incident_data
 
     # Claim

--- a/test/e2etest.py
+++ b/test/e2etest.py
@@ -1541,7 +1541,8 @@ def test_post_dynamic_incident(sample_user, sample_team, sample_application_name
     incident_response = re.json()
     incident_response.pop('created')
     incident_response.pop('id')
-    incident_response['dynamic_tracking'].pop('incident_id')
+    for notification in incident_response['dynamic_tracking']:
+        notification.pop('incident_id')
     assert incident_response == incident_data
 
     # Claim


### PR DESCRIPTION
Allow for providing tracking notification destinations on incident creation time

Create a new dynamic_tracking_notification table to allow piggybacking off of the existing template/plan UI and still allow arbitrary tracking notifications to be specified on incident creation time. This will work similarly to how dynamic plans work today where the targets passed at incident creation time and are stored in a dynamic_plan_map table ato be later used to render the appropriate messages to the ad-hoc targets. 

To leverage this new feature a client would pass at incident creation, in addition to the context, a dynamic_tracking_notifications json field with the type of message and destinations for their dynamic tracking notifications. If a plan has dynamic_tracking enabled then the message processor will ignore the plan defined tracking notification and reuse the tracking template defined in the plan with the targets provided in dynamic_tracking_notifications. If the processor can’t find an appropriate template it will create an error message to expose the rendering failure to the end user like it currently exposes other messages that fail to send or render. In order to make this more explicit we will also add an extra `dynamic_tracking` tinyint(1) NOT NULL DEFAULT '0' column to the plan table and a checkbox in the plan editing UI so users can specify if they want to enable dynamic tracking messages for that plan

The contents of the dynamic_tracking_notifications table will be purged when the corresponding incidents are purged for retention.
